### PR TITLE
Feature/scxml 234 js evaluator

### DIFF
--- a/src/main/java/org/apache/commons/scxml2/env/javascript/JSBindings.java
+++ b/src/main/java/org/apache/commons/scxml2/env/javascript/JSBindings.java
@@ -326,7 +326,7 @@ public class JSBindings implements Bindings {
      * </p>
      * @return true if a global bindings (i.e. nashorn Global instance) was ever set by the script engine
      */
-    private boolean hasGlobalBindings() {
+    boolean hasGlobalBindings() {
         if (bindings.containsKey(NASHORN_GLOBAL)) {
             return true;
         }
@@ -338,7 +338,7 @@ public class JSBindings implements Bindings {
      * Return the global bindings (i.e. nashorn Global instance) set by the script engine if existing.
      * @return the global bindings (i.e. nashorn Global instance) set by the script engine, or null if not existing.
      */
-    private Bindings getGlobalBindings() {
+    Bindings getGlobalBindings() {
         if (bindings.containsKey(NASHORN_GLOBAL)) {
             return (Bindings) bindings.get(NASHORN_GLOBAL);
         }

--- a/src/main/java/org/apache/commons/scxml2/env/javascript/JSBindings.java
+++ b/src/main/java/org/apache/commons/scxml2/env/javascript/JSBindings.java
@@ -35,6 +35,8 @@ import org.apache.commons.scxml2.Context;
  */
 public class JSBindings implements Bindings {
 
+    private static final String NASHORN_GLOBAL = "nashorn.global";
+
     // INSTANCE VARIABLES
 
     private Bindings bindings;
@@ -52,7 +54,7 @@ public class JSBindings implements Bindings {
      *         or <code>bindings</code> is <code>null</code>.
      *
      */
-    public JSBindings(Context context,Bindings bindings) {
+    public JSBindings(Context context, Bindings bindings) {
         // ... validate
 
         if (context == null) {
@@ -63,10 +65,10 @@ public class JSBindings implements Bindings {
            throw new IllegalArgumentException("Invalid script Bindings");
         }
 
-         // ... initialise
+        // ... initialise
 
-         this.bindings = bindings;
-         this.context  = context;
+        this.bindings = bindings;
+        this.context = context;
     }
 
     // INSTANCE METHODS
@@ -79,8 +81,13 @@ public class JSBindings implements Bindings {
      */
     @Override
     public boolean containsKey(Object key) {
-        if (bindings.containsKey(key))
-           return true;
+        if (hasGlobalBindings() && getGlobalBindings().containsKey(key)) {
+            return true;
+        }
+
+        if (bindings.containsKey(key)) {
+            return true;
+        }
 
         return context.has(key.toString());
     }
@@ -98,6 +105,10 @@ public class JSBindings implements Bindings {
 
         keys.addAll(context.getVars().keySet());
         keys.addAll(bindings.keySet());
+
+        if (hasGlobalBindings()) {
+            keys.addAll(getGlobalBindings().keySet());
+        }
 
         return keys;
     }
@@ -117,6 +128,10 @@ public class JSBindings implements Bindings {
         keys.addAll(context.getVars().keySet());
         keys.addAll(bindings.keySet());
 
+        if (hasGlobalBindings()) {
+            keys.addAll(getGlobalBindings().keySet());
+        }
+
         return keys.size();
     }
 
@@ -129,8 +144,13 @@ public class JSBindings implements Bindings {
      */
     @Override
     public boolean containsValue(Object value) {
-        if (bindings.containsValue(value))
-           return true;
+        if (hasGlobalBindings() && getGlobalBindings().containsValue(value)) {
+            return true;
+        }
+
+        if (bindings.containsValue(value)) {
+            return true;
+        }
 
         return context.getVars().containsValue(value);
     }
@@ -168,8 +188,13 @@ public class JSBindings implements Bindings {
      */
     @Override
     public boolean isEmpty() {
-        if (!bindings.isEmpty())
-           return false;
+        if (hasGlobalBindings() && !getGlobalBindings().isEmpty()) {
+            return false;
+        }
+
+        if (!bindings.isEmpty()) {
+            return false;
+        }
 
         return context.getVars().isEmpty();
     }
@@ -181,8 +206,13 @@ public class JSBindings implements Bindings {
      */
     @Override
     public Object get(Object key) {
-        if (bindings.containsKey(key))
-           return bindings.get(key);
+        if (hasGlobalBindings() && getGlobalBindings().containsKey(key)) {
+            return getGlobalBindings().get(key);
+        }
+
+        if (bindings.containsKey(key)) {
+            return bindings.get(key);
+        }
 
         return context.get(key.toString());
     }
@@ -201,13 +231,17 @@ public class JSBindings implements Bindings {
     @Override
     public Object put(String name, Object value) {
         Object old = context.get(name);
+
         if (context.has(name)) {
             context.set(name, value);
         } else if (bindings.containsKey(name)) {
             return bindings.put(name,value);
+        } else if (hasGlobalBindings() && getGlobalBindings().containsKey(name)) {
+            return getGlobalBindings().put(name, value);
         } else {
             context.setLocal(name, value);
         }
+
         return old;
     }
 
@@ -220,7 +254,7 @@ public class JSBindings implements Bindings {
      */
     @Override
     public void putAll(Map<? extends String, ? extends Object> list) {
-            bindings.putAll(list);
+        bindings.putAll(list);
     }
 
     /**
@@ -234,11 +268,17 @@ public class JSBindings implements Bindings {
      */
     @Override
     public Object remove(Object key) {
-        if (bindings.containsKey(key))
-           return bindings.remove(key);
+        if (hasGlobalBindings() && getGlobalBindings().containsKey(key)) {
+            getGlobalBindings().remove(key);
+        }
 
-        if (context.has(key.toString()))
-           return context.getVars().remove(key);
+        if (bindings.containsKey(key)) {
+            return bindings.remove(key);
+        }
+
+        if (context.has(key.toString())) {
+            return context.getVars().remove(key);
+        }
 
         return Boolean.FALSE;
     }
@@ -252,7 +292,7 @@ public class JSBindings implements Bindings {
      */
     @Override
     public void clear() {
-            bindings.clear();
+        bindings.clear();
     }
 
     /**
@@ -265,11 +305,48 @@ public class JSBindings implements Bindings {
 
         set.putAll(context.getVars());
 
-        for (String key: bindings.keySet())
-            set.put(key,bindings.get(key));
+        for (String key : bindings.keySet()) {
+            set.put(key, bindings.get(key));
+        }
+
+        if (hasGlobalBindings()) {
+            for (String key : getGlobalBindings().keySet()) {
+                set.put(key, getGlobalBindings().get(key));
+            }
+        }
 
         return set;
     }
 
-}
+    /**
+     * Return true if a global bindings (i.e. nashorn Global instance) was ever set by the script engine.
+     * <p>
+     * Note: because the global binding can be set by the script engine when evaluating a script, we should
+     *       check or retrieve the global binding whenever needed instead of initialization time.
+     * </p>
+     * @return true if a global bindings (i.e. nashorn Global instance) was ever set by the script engine
+     */
+    private boolean hasGlobalBindings() {
+        if (bindings.containsKey(NASHORN_GLOBAL)) {
+            return true;
+        }
 
+        return context.has(NASHORN_GLOBAL);
+    }
+
+    /**
+     * Return the global bindings (i.e. nashorn Global instance) set by the script engine if existing.
+     * @return the global bindings (i.e. nashorn Global instance) set by the script engine, or null if not existing.
+     */
+    private Bindings getGlobalBindings() {
+        if (bindings.containsKey(NASHORN_GLOBAL)) {
+            return (Bindings) bindings.get(NASHORN_GLOBAL);
+        }
+
+        if (context.has(NASHORN_GLOBAL)) {
+            return (Bindings) context.get(NASHORN_GLOBAL);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/org/apache/commons/scxml2/env/javascript/JSContext.java
+++ b/src/main/java/org/apache/commons/scxml2/env/javascript/JSContext.java
@@ -17,6 +17,8 @@
 
 package org.apache.commons.scxml2.env.javascript;
 
+import java.util.Map;
+
 import org.apache.commons.scxml2.Context;
 import org.apache.commons.scxml2.env.SimpleContext;
 
@@ -44,13 +46,22 @@ public class JSContext extends SimpleContext {
     }
 
     /**
+     * Constructor with initial vars.
+     * @param parent The parent context
+     * @param initialVars The initial set of variables.
+     */
+    public JSContext(final Context parent, final Map<String, Object> initialVars) {
+        super(parent, initialVars);
+    }
+
+    /**
      * Child constructor. Just invokes the identical SimpleContext
      * constructor.
      *
      * @param parent Parent context for this context.
      *
      */
-    public JSContext(Context parent) {
+    public JSContext(final Context parent) {
         super(parent);
     }
 

--- a/src/test/java/org/apache/commons/scxml2/env/javascript/JSEvaluatorTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/javascript/JSEvaluatorTest.java
@@ -19,6 +19,10 @@ package org.apache.commons.scxml2.env.javascript;
 
 import java.io.StringReader;
 
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
 import org.apache.commons.scxml2.Context;
 import org.apache.commons.scxml2.Evaluator;
 import org.apache.commons.scxml2.SCXMLExecutor;
@@ -30,10 +34,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
-
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathFactory;
 
 /** JUnit 3 test case for the JSEvaluator expression evaluator
  *  class. Includes basic tests for:
@@ -143,6 +143,21 @@ public class JSEvaluatorTest {
 
         Assert.assertNotNull(evaluator);
         Assert.assertTrue   (((Boolean) evaluator.eval(context, "1+1 == 2")).booleanValue());
+    }
+
+    @Test
+    public void testScript() throws SCXMLExpressionException {
+        Evaluator evaluator = new JSEvaluator();
+        context.set("x", 3);
+        context.set("y", 0);
+        String script = 
+            "if ((x * 2.0) == 5.0) {" +
+                "y = 1.0;\n" +
+            "} else {\n" +
+                "y = 2.0;\n" +
+            "}";
+        Assert.assertEquals(2.0, evaluator.evalScript(context, script));
+        Assert.assertEquals(2.0, context.get("y"));
     }
 
     /**

--- a/src/test/java/org/apache/commons/scxml2/env/javascript/JavaScriptEngineTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/javascript/JavaScriptEngineTest.java
@@ -16,17 +16,79 @@
  */
 package org.apache.commons.scxml2.env.javascript;
 
+import static org.junit.Assert.assertEquals;
+
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+
+import org.apache.commons.scxml2.Context;
 import org.junit.Before;
 import org.junit.Test;
 
 public class JavaScriptEngineTest {
 
+    private ScriptEngine engine;
+
+    private Context context;
+
     @Before
     public void before() throws Exception {
-        
+        ScriptEngineManager factory = new ScriptEngineManager();
+        engine = factory.getEngineByName("JavaScript");
+        context = new JSContext();
     }
 
     @Test
-    public void testX() throws Exception {
+    public void testSimpleEvaluation() throws Exception {
+        Object ret = engine.eval("1.0 + 2.0");
+        assertEquals(3.0, ret);
+    }
+
+    @Test
+    public void testBindingsInput() throws Exception {
+        Bindings bindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
+        bindings.put("x", 1.0);
+        bindings.put("y", 2.0);
+
+        Object ret = engine.eval("x + y;", bindings);
+        assertEquals(3.0, ret);
+    }
+
+    @Test
+    public void testBindingsInput_WithJSBindings() throws Exception {
+        Bindings bindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
+        JSBindings jsBindings = new JSBindings(context, bindings);
+        jsBindings.put("x", 1.0);
+        jsBindings.put("y", 2.0);
+
+        Object ret = engine.eval("x + y;", jsBindings);
+        assertEquals(3.0, ret);
+    }
+
+    @Test
+    public void testBindingsGlobal() throws Exception {
+        Bindings bindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
+        bindings.put("x", 1.0);
+        bindings.put("y", 2.0);
+        bindings.put("z", 0.0);
+
+        engine.eval("z = x + y;", bindings);
+        assertEquals("z variable is expected to set to 3.0 in global, but it was " + bindings.get("z") + ".",
+                     3.0, bindings.get("z"));
+    }
+
+    @Test
+    public void testBindingsGlobal_WithJSBindings() throws Exception {
+        Bindings bindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
+        JSBindings jsBindings = new JSBindings(context, bindings);
+        jsBindings.put("x", 1.0);
+        jsBindings.put("y", 2.0);
+        jsBindings.put("z", 0.0);
+
+        engine.eval("z = x + y;", jsBindings);
+        assertEquals("z variable is expected to set to 3.0 in global, but it was " + jsBindings.get("z") + ".",
+                     3.0, jsBindings.get("z"));
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/env/javascript/JavaScriptEngineTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/javascript/JavaScriptEngineTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.scxml2.env.javascript;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class JavaScriptEngineTest {
+
+    @Before
+    public void before() throws Exception {
+        
+    }
+
+    @Test
+    public void testX() throws Exception {
+    }
+}


### PR DESCRIPTION
Fixed ScriptTest unit test failure.
The root cause was as follows:
- In Java 1.8, the global object ("nashorn.global") is not shared with the engine-level bindings any more. Therefore, after evaluating a script, you should retrieve the global to read it:

    Object nashornGlobal = ((Bindings)obj).get("nashorn.global"); 

- Fixed JSEvaluator by copying global variables after evaluation to the SCXML Context object.
- Change JSContext to be aligned with other context objects by using EffectiveContextMap like JexlContext and JexlEvaluator do.

[1] https://wiki.openjdk.java.net/display/Nashorn/Nashorn+jsr223+engine+notes