### PR TITLE
SCXML-251: Parse src attribute of data elements

### DIFF
--- a/src/main/java/org/apache/commons/scxml2/io/SCXMLReader.java
+++ b/src/main/java/org/apache/commons/scxml2/io/SCXMLReader.java
@@ -1094,7 +1094,21 @@ public final class SCXMLReader {
 
         Data datum = new Data();
         datum.setId(readRequiredAV(reader, ELEM_DATA, ATTR_ID));
-        datum.setExpr(readAV(reader, ATTR_EXPR));
+        final String expr = readAV(reader, ATTR_EXPR);
+        final String src = readAV(reader, ATTR_SRC);
+
+        if (expr != null && src != null) {
+          LogFactory.getLog(SCXMLReader.class).error(
+              "Found src and expr attributes for data node '" + datum.getId() + "', which is not valid SCXML.");
+          throw new ModelException();
+        }
+        if (expr != null) {
+            datum.setExpr(expr);
+        }
+        if (src != null) {
+          datum.setSrc(src);
+        }
+
         readNamespaces(configuration, datum);
         Node node = readNode(reader, configuration, XMLNS_SCXML, ELEM_DATA, new String[]{"id"});
         datum.setNode(node);

--- a/src/main/java/org/apache/commons/scxml2/io/SCXMLReader.java
+++ b/src/main/java/org/apache/commons/scxml2/io/SCXMLReader.java
@@ -1097,16 +1097,15 @@ public final class SCXMLReader {
         final String expr = readAV(reader, ATTR_EXPR);
         final String src = readAV(reader, ATTR_SRC);
 
-        if (expr != null && src != null) {
-          LogFactory.getLog(SCXMLReader.class).error(
-              "Found src and expr attributes for data node '" + datum.getId() + "', which is not valid SCXML.");
-          throw new ModelException();
-        }
         if (expr != null) {
+            if (src != null) {
+                reportConflictingAttribute(reader, configuration, ELEM_DATA, ATTR_EXPR, ATTR_SRC);
+            }
             datum.setExpr(expr);
-        }
-        if (src != null) {
-          datum.setSrc(src);
+        } else {
+            if (src != null) {
+                datum.setSrc(src);
+            }
         }
 
         readNamespaces(configuration, datum);

--- a/src/test/java/org/apache/commons/scxml2/io/SCXMLReaderTest.java
+++ b/src/test/java/org/apache/commons/scxml2/io/SCXMLReaderTest.java
@@ -278,6 +278,23 @@ public class SCXMLReaderTest {
         Assert.assertNotNull(scxml.getGlobalScript());
     }
 
+    @Test(expected=org.apache.commons.scxml2.model.ModelException.class)
+    public void dataWithSrcAndExprIsRejected() throws Exception {
+      SCXMLTestHelper.parse("org/apache/commons/scxml2/io/data-with-src-and-expr.xml");
+    }
+
+    @Test
+    public void srcAttributeOfDataIsParsed() throws Exception {
+      SCXML scxml = SCXMLTestHelper.parse("org/apache/commons/scxml2/io/data-with-src.xml");
+      Assert.assertNotNull(scxml);
+      Assert.assertNotNull(scxml.getDatamodel());
+      Assert.assertNotNull(scxml.getDatamodel().getData());
+      Assert.assertEquals("Exactly one data element parsed.", 1, scxml.getDatamodel().getData().size());
+      Data data = scxml.getDatamodel().getData().get(0);
+      Assert.assertNotNull(data);
+      Assert.assertEquals("http://www.w3.org/TR/sxcml", data.getSrc());
+    }
+
     private String serialize(final SCXML scxml) throws IOException, XMLStreamException {
         String scxmlAsString = SCXMLWriter.write(scxml);
         Assert.assertNotNull(scxmlAsString);

--- a/src/test/java/org/apache/commons/scxml2/io/SCXMLReaderTest.java
+++ b/src/test/java/org/apache/commons/scxml2/io/SCXMLReaderTest.java
@@ -279,20 +279,50 @@ public class SCXMLReaderTest {
     }
 
     @Test(expected=org.apache.commons.scxml2.model.ModelException.class)
-    public void dataWithSrcAndExprIsRejected() throws Exception {
-      SCXMLTestHelper.parse("org/apache/commons/scxml2/io/data-with-src-and-expr.xml");
+    public void dataWithSrcAndExprIsRejectedInStrictConfiguration() throws Exception {
+        Configuration configuration = new Configuration();
+        configuration.setStrict(true);
+        configuration.setSilent(true);
+        SCXMLReader.read(getClass().getResourceAsStream("data-with-src-and-expr.xml"), configuration);
+    }
+
+    @Test
+    public void dataWithSrcAndExprUsesExprInNonStrictConfiguration() throws Exception {
+        Configuration configuration = new Configuration();
+        configuration.setStrict(false);
+        configuration.setSilent(true);
+        SCXML scxml = SCXMLReader.read(getClass().getResourceAsStream("data-with-src-and-expr.xml"), configuration);
+        Assert.assertNotNull(scxml);
+        Assert.assertNotNull(scxml.getDatamodel());
+        Assert.assertNotNull(scxml.getDatamodel().getData());
+        Assert.assertEquals("Exactly one data element parsed.", 1, scxml.getDatamodel().getData().size());
+        Data data = scxml.getDatamodel().getData().get(0);
+        Assert.assertNotNull(data);
+        Assert.assertEquals("'an expression'", data.getExpr());
     }
 
     @Test
     public void srcAttributeOfDataIsParsed() throws Exception {
-      SCXML scxml = SCXMLTestHelper.parse("org/apache/commons/scxml2/io/data-with-src.xml");
+        SCXML scxml = SCXMLTestHelper.parse("org/apache/commons/scxml2/io/data-with-src.xml");
+        Assert.assertNotNull(scxml);
+        Assert.assertNotNull(scxml.getDatamodel());
+        Assert.assertNotNull(scxml.getDatamodel().getData());
+        Assert.assertEquals("Exactly one data element parsed.", 1, scxml.getDatamodel().getData().size());
+        Data data = scxml.getDatamodel().getData().get(0);
+        Assert.assertNotNull(data);
+        Assert.assertEquals("http://www.w3.org/TR/sxcml", data.getSrc());
+    }
+
+    @Test
+    public void exprAttributeOfDataIsParsed() throws Exception {
+      SCXML scxml = SCXMLTestHelper.parse("org/apache/commons/scxml2/io/data-with-expr.xml");
       Assert.assertNotNull(scxml);
       Assert.assertNotNull(scxml.getDatamodel());
       Assert.assertNotNull(scxml.getDatamodel().getData());
       Assert.assertEquals("Exactly one data element parsed.", 1, scxml.getDatamodel().getData().size());
       Data data = scxml.getDatamodel().getData().get(0);
       Assert.assertNotNull(data);
-      Assert.assertEquals("http://www.w3.org/TR/sxcml", data.getSrc());
+      Assert.assertEquals("'an expression'", data.getExpr());
     }
 
     private String serialize(final SCXML scxml) throws IOException, XMLStreamException {

--- a/src/test/java/org/apache/commons/scxml2/io/SCXMLReaderTest.java
+++ b/src/test/java/org/apache/commons/scxml2/io/SCXMLReaderTest.java
@@ -315,14 +315,14 @@ public class SCXMLReaderTest {
 
     @Test
     public void exprAttributeOfDataIsParsed() throws Exception {
-      SCXML scxml = SCXMLTestHelper.parse("org/apache/commons/scxml2/io/data-with-expr.xml");
-      Assert.assertNotNull(scxml);
-      Assert.assertNotNull(scxml.getDatamodel());
-      Assert.assertNotNull(scxml.getDatamodel().getData());
-      Assert.assertEquals("Exactly one data element parsed.", 1, scxml.getDatamodel().getData().size());
-      Data data = scxml.getDatamodel().getData().get(0);
-      Assert.assertNotNull(data);
-      Assert.assertEquals("'an expression'", data.getExpr());
+        SCXML scxml = SCXMLTestHelper.parse("org/apache/commons/scxml2/io/data-with-expr.xml");
+        Assert.assertNotNull(scxml);
+        Assert.assertNotNull(scxml.getDatamodel());
+        Assert.assertNotNull(scxml.getDatamodel().getData());
+        Assert.assertEquals("Exactly one data element parsed.", 1, scxml.getDatamodel().getData().size());
+        Data data = scxml.getDatamodel().getData().get(0);
+        Assert.assertNotNull(data);
+        Assert.assertEquals("'an expression'", data.getExpr());
     }
 
     private String serialize(final SCXML scxml) throws IOException, XMLStreamException {

--- a/src/test/java/org/apache/commons/scxml2/io/data-with-expr.xml
+++ b/src/test/java/org/apache/commons/scxml2/io/data-with-expr.xml
@@ -21,7 +21,7 @@
        initial="foo">
 
     <datamodel>
-        <data id="theData" src="http://www.w3.org/TR/sxcml" expr="'an expression'" />
+        <data id="theData" expr="'an expression'" />
     </datamodel>
 
     <final id="foo"/>

--- a/src/test/java/org/apache/commons/scxml2/io/data-with-src-and-expr.xml
+++ b/src/test/java/org/apache/commons/scxml2/io/data-with-src-and-expr.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+-->
+<!-- Used for SrcTest.java in io package -->
+<scxml xmlns="http://www.w3.org/2005/07/scxml"
+       version="1.0"
+       initial="foo">
+
+    <datamodel>
+        <data id="theData" src="http://www.w3.org/TR/sxcml" expr="'a value'" />
+    </datamodel>
+
+    <final id="foo"/>
+
+</scxml>

--- a/src/test/java/org/apache/commons/scxml2/io/data-with-src.xml
+++ b/src/test/java/org/apache/commons/scxml2/io/data-with-src.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+-->
+<!-- Used for SrcTest.java in io package -->
+<scxml xmlns="http://www.w3.org/2005/07/scxml"
+       version="1.0"
+       initial="foo">
+
+    <datamodel>
+        <data id="theData" src="http://www.w3.org/TR/sxcml" />
+    </datamodel>
+
+    <final id="foo"/>
+
+</scxml>


### PR DESCRIPTION
Also: reject data elements which have src and data defined.
According to the scxml standard only either src or data are allowed.