### PR TITLE
SCXML-283 Upgrade to JUnit Jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-parent</artifactId>
-    <version>39</version>
+    <version>47</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -170,9 +170,15 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.3.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.3.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/org/apache/commons/scxml2/EventDataTest.java
+++ b/src/test/java/org/apache/commons/scxml2/EventDataTest.java
@@ -21,8 +21,8 @@ import java.util.Set;
 import org.apache.commons.scxml2.env.Tracer;
 import org.apache.commons.scxml2.model.EnterableState;
 import org.apache.commons.scxml2.model.SCXML;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 /**
  * Unit tests {@link org.apache.commons.scxml2.SCXMLExecutor}.
  * Testing special variable "_event.data"
@@ -37,21 +37,21 @@ public class EventDataTest {
     	SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/env/jexl/eventdata-01.xml");
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("state1", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("state1", currentStates.iterator().next().getId());
         TriggerEvent te = new EventBuilder("event.foo", TriggerEvent.SIGNAL_EVENT).data(3).build();
         currentStates = SCXMLTestHelper.fireEvent(exec, te);
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("state3", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("state3", currentStates.iterator().next().getId());
         TriggerEvent[] evts = new TriggerEvent[] { te,
             new EventBuilder("event.bar", TriggerEvent.SIGNAL_EVENT).data(6).build()};
         currentStates = SCXMLTestHelper.fireEvents(exec, evts);
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("state6", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("state6", currentStates.iterator().next().getId());
         te = new EventBuilder("event.baz", TriggerEvent.SIGNAL_EVENT).data(7).build();
         currentStates = SCXMLTestHelper.fireEvent(exec, te);
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("state7", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("state7", currentStates.iterator().next().getId());
     }
 
     @Test
@@ -59,17 +59,17 @@ public class EventDataTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/env/jexl/eventdata-02.xml");
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("state0", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("state0", currentStates.iterator().next().getId());
         TriggerEvent te1 = new EventBuilder("connection.alerting", TriggerEvent.SIGNAL_EVENT).data("line2").build();
         currentStates = SCXMLTestHelper.fireEvent(exec, te1);
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("state2", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("state2", currentStates.iterator().next().getId());
         TriggerEvent te2 = new EventBuilder("connection.alerting", TriggerEvent.SIGNAL_EVENT)
                 .data(new ConnectionAlertingPayload(4)).build();
         currentStates = SCXMLTestHelper.fireEvent(exec, te2);
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("state4", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("state4", currentStates.iterator().next().getId());
     }
 
     @Test
@@ -77,12 +77,12 @@ public class EventDataTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/env/jexl/eventdata-03.xml");
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("ten", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("ten", currentStates.iterator().next().getId());
         TriggerEvent te = new EventBuilder("event.foo", TriggerEvent.SIGNAL_EVENT).build();
         currentStates = SCXMLTestHelper.fireEvent(exec, te);
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("thirty", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("thirty", currentStates.iterator().next().getId());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/scxml2/SCInstanceTest.java
+++ b/src/test/java/org/apache/commons/scxml2/SCInstanceTest.java
@@ -24,16 +24,16 @@ import org.apache.commons.scxml2.env.jexl.JexlEvaluator;
 import org.apache.commons.scxml2.model.EnterableState;
 import org.apache.commons.scxml2.model.History;
 import org.apache.commons.scxml2.model.State;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SCInstanceTest {
 
     private SCXMLExecutor executor;
     private SCInstance instance;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         executor = new SCXMLExecutor();
         instance = executor.getSCInstance();
@@ -45,7 +45,7 @@ public class SCInstanceTest {
         context.set("name", "value");
         
         instance.setRootContext(context);
-        Assert.assertEquals("value", instance.getRootContext().get("name"));
+        Assertions.assertEquals("value", instance.getRootContext().get("name"));
     }
     
     @Test
@@ -58,7 +58,7 @@ public class SCInstanceTest {
         
         instance.setContext(target, context);
         
-        Assert.assertEquals("value", instance.getContext(target).get("name"));
+        Assertions.assertEquals("value", instance.getContext(target).get("name"));
     }
     
     @Test
@@ -73,8 +73,8 @@ public class SCInstanceTest {
         Evaluator evaluator = new JexlEvaluator();
         executor.setEvaluator(evaluator);
 
-        Assert.assertEquals("value", instance.getContext(target).get("name"));
-        Assert.assertEquals("value", instance.lookupContext(target).get("name"));
+        Assertions.assertEquals("value", instance.getContext(target).get("name"));
+        Assertions.assertEquals("value", instance.lookupContext(target).get("name"));
     }
 
     @Test
@@ -94,8 +94,8 @@ public class SCInstanceTest {
         Evaluator evaluator = new JexlEvaluator();
         executor.setEvaluator(evaluator);
 
-        Assert.assertEquals("value", instance.getContext(target).get("name"));
-        Assert.assertEquals("value", instance.lookupContext(target).get("name"));
+        Assertions.assertEquals("value", instance.getContext(target).get("name"));
+        Assertions.assertEquals("value", instance.lookupContext(target).get("name"));
     }
 
     @Test
@@ -104,7 +104,7 @@ public class SCInstanceTest {
         
         Set<EnterableState> returnConfiguration = instance.getLastConfiguration(history);
         
-        Assert.assertEquals(0, returnConfiguration.size());
+        Assertions.assertEquals(0, returnConfiguration.size());
     }
 
     @Test
@@ -122,14 +122,14 @@ public class SCInstanceTest {
         
         Set<EnterableState> returnConfiguration = instance.getLastConfiguration(history);
         
-        Assert.assertEquals(2, returnConfiguration.size());
-        Assert.assertTrue(returnConfiguration.contains(tt1));
-        Assert.assertTrue(returnConfiguration.contains(tt2));
+        Assertions.assertEquals(2, returnConfiguration.size());
+        Assertions.assertTrue(returnConfiguration.contains(tt1));
+        Assertions.assertTrue(returnConfiguration.contains(tt2));
     }
     
     @Test
     public void testIsEmpty() {
-        Assert.assertTrue(instance.getLastConfiguration(new History()).isEmpty());
+        Assertions.assertTrue(instance.getLastConfiguration(new History()).isEmpty());
     }
     
     @Test
@@ -143,7 +143,7 @@ public class SCInstanceTest {
         
         instance.setLastConfiguration(history, configuration);  
 
-        Assert.assertFalse(instance.getLastConfiguration(history).isEmpty());
+        Assertions.assertFalse(instance.getLastConfiguration(history).isEmpty());
     }
     
     @Test
@@ -159,7 +159,7 @@ public class SCInstanceTest {
 
         instance.resetConfiguration(history);
         
-        Assert.assertTrue(instance.getLastConfiguration(history).isEmpty());
+        Assertions.assertTrue(instance.getLastConfiguration(history).isEmpty());
     }
     
 }

--- a/src/test/java/org/apache/commons/scxml2/SCXMLExecutorTest.java
+++ b/src/test/java/org/apache/commons/scxml2/SCXMLExecutorTest.java
@@ -23,8 +23,8 @@ import java.util.Set;
 
 import org.apache.commons.scxml2.model.EnterableState;
 import org.apache.commons.scxml2.model.TransitionTarget;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 /**
  * Unit tests {@link org.apache.commons.scxml2.SCXMLExecutor}.
  */
@@ -108,11 +108,11 @@ public class SCXMLExecutorTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/prefix-01.xml");
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("ten", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("ten", currentStates.iterator().next().getId());
         currentStates = SCXMLTestHelper.fireEvent(exec, "done.state.ten");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("twenty", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("twenty", currentStates.iterator().next().getId());
     }
 
     @Test
@@ -120,13 +120,13 @@ public class SCXMLExecutorTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/transitions-01.xml");
         exec.go();
         Set<EnterableState> currentStates = SCXMLTestHelper.fireEvent(exec, "done.state.ten");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("twenty_one", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("twenty_one", currentStates.iterator().next().getId());
         currentStates = SCXMLTestHelper.fireEvent(exec, "done.state.twenty_one");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("twenty_two", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("twenty_two", currentStates.iterator().next().getId());
         SCXMLTestHelper.fireEvent(exec, "done.state.twenty_two");
-        Assert.assertEquals(3, exec.getStatus().getStates().size());
+        Assertions.assertEquals(3, exec.getStatus().getStates().size());
     }
 
     @Test
@@ -134,15 +134,15 @@ public class SCXMLExecutorTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/transitions-02.xml");
         exec.go();
         Set<EnterableState> currentStates = SCXMLTestHelper.fireEvent(exec, "ten.stay");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("ten", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("ten", currentStates.iterator().next().getId());
         exec = SCXMLTestHelper.testInstanceSerializability(exec);
         currentStates = SCXMLTestHelper.fireEvent(exec, "ten.self");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("ten", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("ten", currentStates.iterator().next().getId());
         currentStates = SCXMLTestHelper.fireEvent(exec, "done.state.ten");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("twenty", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("twenty", currentStates.iterator().next().getId());
     }
 
     @Test
@@ -150,14 +150,14 @@ public class SCXMLExecutorTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/transitions-03.xml");
         exec.go();
         Set<EnterableState> currentStates = SCXMLTestHelper.fireEvent(exec, "done.state.ten");
-        Assert.assertEquals(3, currentStates.size());
+        Assertions.assertEquals(3, currentStates.size());
         Set<String> expected = new HashSet<>();
         expected.add("twenty_one_2");
         expected.add("twenty_two_2");
         expected.add("twenty_three_2");
         for (TransitionTarget tt : currentStates) {
             if (!expected.remove(tt.getId())) {
-                Assert.fail("'" + tt.getId()
+                Assertions.fail("'" + tt.getId()
                     + "' is not an expected current state ID");
             }
         }
@@ -168,20 +168,20 @@ public class SCXMLExecutorTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/transitions-04.xml");
         exec.go();
         Set<EnterableState> currentStates = SCXMLTestHelper.fireEvent(exec, "done.state.ten");
-        Assert.assertEquals(3, currentStates.size());
+        Assertions.assertEquals(3, currentStates.size());
         Set<String> expected = new HashSet<>();
         expected.add("twenty_one_1");
         expected.add("twenty_two_1");
         expected.add("twenty_three_1");
         for (TransitionTarget tt : currentStates) {
             if (!expected.remove(tt.getId())) {
-                Assert.fail("'" + tt.getId()
+                Assertions.fail("'" + tt.getId()
                     + "' is not an expected current state ID");
             }
         }
         currentStates = SCXMLTestHelper.fireEvent(exec, "bar");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("thirty", (currentStates.iterator().
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("thirty", (currentStates.iterator().
             next()).getId());
     }
 
@@ -207,11 +207,11 @@ public class SCXMLExecutorTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/send-01.xml");
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("ten", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("ten", currentStates.iterator().next().getId());
         currentStates = SCXMLTestHelper.fireEvent(exec, "done.state.ten");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("twenty", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("twenty", currentStates.iterator().next().getId());
     }
 
     @Test
@@ -219,9 +219,9 @@ public class SCXMLExecutorTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/send-02.xml");
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("ninety", currentStates.iterator().next().getId());
-        Assert.assertTrue(exec.getStatus().isFinal());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("ninety", currentStates.iterator().next().getId());
+        Assertions.assertTrue(exec.getStatus().isFinal());
     }
 
     @Test
@@ -267,38 +267,38 @@ public class SCXMLExecutorTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/transitions-01.xml");
         exec.go();
         Set<EnterableState> currentStates = SCXMLTestHelper.fireEvent(exec, "done.state.ten");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("twenty_one", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("twenty_one", currentStates.iterator().next().getId());
         currentStates = SCXMLTestHelper.fireEvent(exec, "done.state.twenty_one");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("twenty_two", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("twenty_two", currentStates.iterator().next().getId());
         Set<String> stateIds = new HashSet<>();
         stateIds.add("twenty_one");
         exec.setConfiguration(stateIds);
-        Assert.assertEquals(1, exec.getStatus().getStates().size());
+        Assertions.assertEquals(1, exec.getStatus().getStates().size());
         SCXMLTestHelper.fireEvent(exec, "done.state.twenty_one");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("twenty_two", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("twenty_two", currentStates.iterator().next().getId());
     }
 
     @Test
     public void testSCXMLExecutorFinalDoneData() throws Exception {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/final-donedata.xml");
-        Assert.assertNull(exec.getFinalDoneData());
+        Assertions.assertNull(exec.getFinalDoneData());
         exec.go();
-        Assert.assertEquals("done", exec.getFinalDoneData());
+        Assertions.assertEquals("done", exec.getFinalDoneData());
     }
 
     private void checkMicrowave01Sample(SCXMLExecutor exec) throws Exception {
         Set<EnterableState> currentStates = SCXMLTestHelper.fireEvent(exec, "turn_on");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("cooking", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("cooking", currentStates.iterator().next().getId());
     }
 
     private void checkMicrowave02Sample(SCXMLExecutor exec) throws Exception {
         Set<EnterableState> currentStates = SCXMLTestHelper.fireEvent(exec, "turn_on");
-        Assert.assertEquals(2, currentStates.size());
+        Assertions.assertEquals(2, currentStates.size());
         String id = (currentStates.iterator().next()).getId();
-        Assert.assertTrue(id.equals("closed") || id.equals("cooking"));
+        Assertions.assertTrue(id.equals("closed") || id.equals("cooking"));
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/SCXMLTestHelper.java
+++ b/src/test/java/org/apache/commons/scxml2/SCXMLTestHelper.java
@@ -36,7 +36,7 @@ import org.apache.commons.scxml2.model.CustomAction;
 import org.apache.commons.scxml2.model.EnterableState;
 import org.apache.commons.scxml2.model.SCXML;
 import org.apache.commons.scxml2.model.TransitionTarget;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * Helper methods for running SCXML unit tests.
@@ -64,7 +64,7 @@ public class SCXMLTestHelper {
     }
 
     public static SCXML parse(final String scxmlResource) throws Exception {
-        Assert.assertNotNull(scxmlResource);
+        Assertions.assertNotNull(scxmlResource);
         return parse(getResource(scxmlResource), null);
     }
 
@@ -73,23 +73,23 @@ public class SCXMLTestHelper {
     }
 
     public static SCXML parse(final String scxmlResource, final List<CustomAction> customActions) throws Exception {
-        Assert.assertNotNull(scxmlResource);
+        Assertions.assertNotNull(scxmlResource);
         return parse(getResource(scxmlResource), customActions);
     }
 
     public static SCXML parse(final URL url, final List<CustomAction> customActions) throws Exception {
-        Assert.assertNotNull(url);
+        Assertions.assertNotNull(url);
         Configuration configuration = new Configuration(null, null, customActions);
         SCXML scxml = SCXMLReader.read(url, configuration);
-        Assert.assertNotNull(scxml);
+        Assertions.assertNotNull(scxml);
         return testModelSerializability(scxml);
     }
 
     public static SCXML parse(final Reader scxmlReader, final List<CustomAction> customActions) throws Exception {
-        Assert.assertNotNull(scxmlReader);
+        Assertions.assertNotNull(scxmlReader);
         Configuration configuration = new Configuration(null, null, customActions);
         SCXML scxml = SCXMLReader.read(scxmlReader, configuration);
-        Assert.assertNotNull(scxml);
+        Assertions.assertNotNull(scxml);
         return testModelSerializability(scxml);
     }
 
@@ -135,10 +135,10 @@ public class SCXMLTestHelper {
 
     public static void assertState(SCXMLExecutor exec, String expectedStateId) {
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals("Expected 1 simple (leaf) state with id '"
-            + expectedStateId + "' but found " + currentStates.size() + " states instead.",
-            1, currentStates.size());
-        Assert.assertEquals(expectedStateId, currentStates.iterator().
+        Assertions.assertEquals(1, currentStates.size(),
+                "Expected 1 simple (leaf) state with id '" + expectedStateId +
+                        "' but found " + currentStates.size() + " states instead.");
+        Assertions.assertEquals(expectedStateId, currentStates.iterator().
             next().getId());
     }
 
@@ -187,38 +187,38 @@ public class SCXMLTestHelper {
     public static void assertPostTriggerState(SCXMLExecutor exec,
             TriggerEvent triggerEvent, String expectedStateId) throws Exception {
         Set<EnterableState> currentStates = fireEvent(exec, triggerEvent);
-        Assert.assertEquals("Expected 1 simple (leaf) state with id '"
-            + expectedStateId + "' on firing event " + triggerEvent
-            + " but found " + currentStates.size() + " states instead.",
-            1, currentStates.size());
-        Assert.assertEquals(expectedStateId, currentStates.iterator().
+        Assertions.assertEquals(1, currentStates.size(),
+                "Expected 1 simple (leaf) state with id '"
+                        + expectedStateId + "' on firing event " + triggerEvent
+                        + " but found " + currentStates.size() + " states instead.");
+        Assertions.assertEquals(expectedStateId, currentStates.iterator().
             next().getId());
     }
 
     public static void assertPostTriggerStates(SCXMLExecutor exec,
             TriggerEvent triggerEvent, String[] expectedStateIds) throws Exception {
         if (expectedStateIds == null || expectedStateIds.length == 0) {
-            Assert.fail("Must specify an array of one or more "
+            Assertions.fail("Must specify an array of one or more "
                 + "expected state IDs");
         }
         Set<EnterableState> currentStates = fireEvent(exec, triggerEvent);
         int n = expectedStateIds.length;
-        Assert.assertEquals("Expected " + n + " simple (leaf) state(s) "
-            + " on firing event " + triggerEvent + " but found "
-            + currentStates.size() + " states instead.",
-            n, currentStates.size());
+        Assertions.assertEquals(n, currentStates.size(),
+                "Expected " + n + " simple (leaf) state(s) "
+                        + " on firing event " + triggerEvent + " but found "
+                        + currentStates.size() + " states instead.");
         List<String> expectedStateIdList = new ArrayList<>(Arrays.asList(expectedStateIds));
         for (TransitionTarget tt : currentStates) {
             String stateId = tt.getId();
             if(!expectedStateIdList.remove(stateId)) {
-                Assert.fail("Expected state with id '" + stateId
+                Assertions.fail("Expected state with id '" + stateId
                     + "' in current states on firing event "
                     + triggerEvent);
             }
         }
-        Assert.assertEquals("More states in current configuration than those"
-            + "specified in the expected state ids '" + Arrays.toString(expectedStateIds)
-            + "'", 0, expectedStateIdList.size());
+        Assertions.assertEquals(0, expectedStateIdList.size(),
+                "More states in current configuration than those"
+                        + "specified in the expected state ids '" + Arrays.toString(expectedStateIds) + "'");
     }
 
     public static SCXML testModelSerializability(final SCXML scxml) throws Exception {

--- a/src/test/java/org/apache/commons/scxml2/StatusTest.java
+++ b/src/test/java/org/apache/commons/scxml2/StatusTest.java
@@ -21,16 +21,16 @@ import java.util.Set;
 import org.apache.commons.scxml2.model.EnterableState;
 import org.apache.commons.scxml2.model.Final;
 import org.apache.commons.scxml2.model.State;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class StatusTest {
 
     private StateConfiguration stateConfiguration;
     private Status status;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         stateConfiguration = new StateConfiguration();
         status = new Status(stateConfiguration);
@@ -42,7 +42,7 @@ public class StatusTest {
 
         stateConfiguration.enterState(state);
         
-        Assert.assertFalse(status.isFinal());
+        Assertions.assertFalse(status.isFinal());
     }
     
     @Test
@@ -52,7 +52,7 @@ public class StatusTest {
         
         stateConfiguration.enterState(state);
 
-        Assert.assertFalse(status.isFinal());
+        Assertions.assertFalse(status.isFinal());
     }
     
     @Test
@@ -61,7 +61,7 @@ public class StatusTest {
 
         stateConfiguration.enterState(state);
 
-        Assert.assertTrue(status.isFinal());
+        Assertions.assertTrue(status.isFinal());
     }
 
     @Test
@@ -69,7 +69,7 @@ public class StatusTest {
 
         Set<EnterableState> returnValue = status.getActiveStates();
 
-        Assert.assertEquals(0, returnValue.size());
+        Assertions.assertEquals(0, returnValue.size());
     }
 
     @Test
@@ -84,7 +84,7 @@ public class StatusTest {
 
         Set<EnterableState> returnValue = status.getActiveStates();
 
-        Assert.assertEquals(2, returnValue.size());
+        Assertions.assertEquals(2, returnValue.size());
     }
 
     @Test
@@ -96,8 +96,8 @@ public class StatusTest {
         state.setId("1");
         state.setParent(parent);
         stateConfiguration.enterState(state);
-        Assert.assertTrue(status.isInState("0"));
-        Assert.assertTrue(status.isInState("1"));
-        Assert.assertFalse(status.isInState("2"));
+        Assertions.assertTrue(status.isInState("0"));
+        Assertions.assertTrue(status.isInState("1"));
+        Assertions.assertFalse(status.isInState("2"));
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/TieBreakerTest.java
+++ b/src/test/java/org/apache/commons/scxml2/TieBreakerTest.java
@@ -20,8 +20,8 @@ import java.util.Set;
 
 import org.apache.commons.scxml2.model.EnterableState;
 import org.apache.commons.scxml2.model.TransitionTarget;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 /**
  * Unit tests for testing conflict resolution amongst multiple transitions
  * within the {@link org.apache.commons.scxml2.SCXMLExecutor}'s default
@@ -41,11 +41,11 @@ public class TieBreakerTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/tie-breaker-01.xml");
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("ten", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("ten", currentStates.iterator().next().getId());
         currentStates = SCXMLTestHelper.fireEvent(exec, "done.state.ten");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("twenty", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("twenty", currentStates.iterator().next().getId());
     }
 
     @Test
@@ -53,11 +53,11 @@ public class TieBreakerTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/tie-breaker-02.xml");
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("eleven", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("eleven", currentStates.iterator().next().getId());
         currentStates = SCXMLTestHelper.fireEvent(exec, "done.state.ten");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("thirty", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("thirty", currentStates.iterator().next().getId());
     }
 
     @Test
@@ -65,11 +65,11 @@ public class TieBreakerTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/tie-breaker-03.xml");
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("eleven", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("eleven", currentStates.iterator().next().getId());
         currentStates = SCXMLTestHelper.fireEvent(exec, "done.state.ten");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("forty", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("forty", currentStates.iterator().next().getId());
     }
 
     @Test
@@ -77,9 +77,9 @@ public class TieBreakerTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/tie-breaker-04.xml");
         exec.go();
         Set<EnterableState> currentStates = SCXMLTestHelper.fireEvent(exec, "event_2");
-        Assert.assertEquals(1, currentStates.size());
+        Assertions.assertEquals(1, currentStates.size());
         currentStates = SCXMLTestHelper.fireEvent(exec, "event_1");
-        Assert.assertEquals(1, currentStates.size());
+        Assertions.assertEquals(1, currentStates.size());
     }
 
     @Test
@@ -87,17 +87,17 @@ public class TieBreakerTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/tie-breaker-05.xml");
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(3, currentStates.size());
+        Assertions.assertEquals(3, currentStates.size());
         for (TransitionTarget tt : currentStates) {
             String id = tt.getId();
-            Assert.assertTrue(id.equals("s11") || id.equals("s212")
+            Assertions.assertTrue(id.equals("s11") || id.equals("s212")
                 || id.equals("s2111"));
         }
         currentStates = SCXMLTestHelper.fireEvent(exec, "event1");
-        Assert.assertEquals(3, currentStates.size());
+        Assertions.assertEquals(3, currentStates.size());
         for (TransitionTarget tt : currentStates) {
             String id = tt.getId();
-            Assert.assertTrue(id.equals("s12") || id.equals("s212")
+            Assertions.assertTrue(id.equals("s12") || id.equals("s212")
                 || id.equals("s2112"));
         }
     }
@@ -107,6 +107,6 @@ public class TieBreakerTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/tie-breaker-06.xml");
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
+        Assertions.assertEquals(1, currentStates.size());
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/TriggerEventTest.java
+++ b/src/test/java/org/apache/commons/scxml2/TriggerEventTest.java
@@ -19,10 +19,10 @@ package org.apache.commons.scxml2;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link org.apache.commons.scxml2.TriggerEvent}.
@@ -37,7 +37,7 @@ public class TriggerEventTest {
     /**
      * Set up instance variables required by this test case.
      */
-    @Before
+    @BeforeEach
     public void setUp() {
         payloadData = new HashMap<>();
         payloadData.put("property1", "value1");
@@ -55,7 +55,7 @@ public class TriggerEventTest {
     /**
      * Tear down instance variables required by this test case.
      */
-    @After
+    @AfterEach
     public void tearDown() {
         payloadData.clear();
         payloadData = null;
@@ -68,32 +68,32 @@ public class TriggerEventTest {
      */
     @Test
     public void testTriggerEventGetters() {
-        Assert.assertEquals("name1", te1.getName());
-        Assert.assertEquals(2, te2.getType());
-        Assert.assertNull(te7.getData());
+        Assertions.assertEquals("name1", te1.getName());
+        Assertions.assertEquals(2, te2.getType());
+        Assertions.assertNull(te7.getData());
     }
 
     @Test
     public void testTriggerEventEquals() {
-        Assert.assertEquals(te1, te2);
-        Assert.assertEquals(te3, te4);
-        Assert.assertEquals(te5, te6);
-        Assert.assertNotEquals(te1, te4);
-        Assert.assertNotNull(te7);
+        Assertions.assertEquals(te1, te2);
+        Assertions.assertEquals(te3, te4);
+        Assertions.assertEquals(te5, te6);
+        Assertions.assertNotEquals(te1, te4);
+        Assertions.assertNotNull(te7);
     }
 
     @Test
     public void testTriggerEventToString() {
-        Assert.assertEquals("TriggerEvent{name=name3, type=4}", te7.toString());
-        Assert.assertEquals("TriggerEvent{name=name1, type=2, data="
+        Assertions.assertEquals("TriggerEvent{name=name3, type=4}", te7.toString());
+        Assertions.assertEquals("TriggerEvent{name=name1, type=2, data="
             + "{property1=value1}}", te2.toString());
     }
 
     @Test
     public void testTriggerEventHashCode() {
-        Assert.assertEquals("TriggerEvent{name=name3, type=4}".hashCode(),
+        Assertions.assertEquals("TriggerEvent{name=name3, type=4}".hashCode(),
             te7.hashCode());
-        Assert.assertEquals("TriggerEvent{name=name3, type=3}".hashCode(),
+        Assertions.assertEquals("TriggerEvent{name=name3, type=3}".hashCode(),
             te5.hashCode());
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/WildcardTest.java
+++ b/src/test/java/org/apache/commons/scxml2/WildcardTest.java
@@ -19,8 +19,8 @@ package org.apache.commons.scxml2;
 import java.util.Set;
 
 import org.apache.commons.scxml2.model.EnterableState;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 /**
  * Unit tests {@link org.apache.commons.scxml2.SCXMLExecutor}.
  * Testing wildcard event matching (*)
@@ -35,12 +35,12 @@ public class WildcardTest {
     	SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/env/jexl/wildcard-01.xml");
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("state1", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("state1", currentStates.iterator().next().getId());
         exec = SCXMLTestHelper.testInstanceSerializability(exec);
         currentStates = SCXMLTestHelper.fireEvent(exec, "foo.bar.baz");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("state4", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("state4", currentStates.iterator().next().getId());
     }
 
     @Test
@@ -48,7 +48,7 @@ public class WildcardTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/env/jexl/wildcard-02.xml");
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("state2", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("state2", currentStates.iterator().next().getId());
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/WizardsTest.java
+++ b/src/test/java/org/apache/commons/scxml2/WizardsTest.java
@@ -22,8 +22,8 @@ import java.util.Set;
 import org.apache.commons.scxml2.env.SimpleDispatcher;
 import org.apache.commons.scxml2.model.EnterableState;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests
@@ -37,24 +37,24 @@ public class WizardsTest {
     public void testWizard01Sample() throws Exception {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/env/jexl/wizard-01.xml");
         exec.go();
-        Assert.assertNotNull(exec);
+        Assertions.assertNotNull(exec);
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("state1", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("state1", currentStates.iterator().next().getId());
         exec = SCXMLTestHelper.testInstanceSerializability(exec);
         currentStates = SCXMLTestHelper.fireEvent(exec, "event2");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("state2", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("state2", currentStates.iterator().next().getId());
         currentStates = SCXMLTestHelper.fireEvent(exec, "event4");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("state4", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("state4", currentStates.iterator().next().getId());
         currentStates = SCXMLTestHelper.fireEvent(exec, "event3");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("state3", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("state3", currentStates.iterator().next().getId());
         exec = SCXMLTestHelper.testInstanceSerializability(exec);
         currentStates = SCXMLTestHelper.fireEvent(exec, "event3"); // ensure we stay put
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("state3", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("state3", currentStates.iterator().next().getId());
     }
 
     @Test
@@ -65,12 +65,12 @@ public class WizardsTest {
         // If you change this, you must also change
         // the TestEventDispatcher
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("state2", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("state2", currentStates.iterator().next().getId());
         exec = SCXMLTestHelper.testInstanceSerializability(exec);
         currentStates = SCXMLTestHelper.fireEvent(exec, "event4");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("state4", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("state4", currentStates.iterator().next().getId());
     }
 
     static class TestEventDispatcher extends SimpleDispatcher {
@@ -86,15 +86,15 @@ public class WizardsTest {
                 int i = ((Integer) params.get("aValue"));
                 switch (callback) {
                     case 0:
-                        Assert.assertTrue(i == 2); // state2
+                        Assertions.assertTrue(i == 2); // state2
                         callback++;
                         break;
                     case 1:
-                        Assert.assertTrue(i == 4); // state4
+                        Assertions.assertTrue(i == 4); // state4
                         callback++;
                         break;
                     default:
-                        Assert.fail("More than 2 TestEventDispatcher <send> callbacks for type \"foo\"");
+                        Assertions.fail("More than 2 TestEventDispatcher <send> callbacks for type \"foo\"");
                 }
             }
             else {
@@ -103,7 +103,7 @@ public class WizardsTest {
         }
         public void cancel(String sendId) {
             // should never be called
-            Assert.fail("<cancel> TestEventDispatcher callback unexpected");
+            Assertions.fail("<cancel> TestEventDispatcher callback unexpected");
         }
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/env/AbstractSCXMLListenerTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/AbstractSCXMLListenerTest.java
@@ -21,10 +21,10 @@ import org.apache.commons.scxml2.model.EnterableState;
 import org.apache.commons.scxml2.model.State;
 import org.apache.commons.scxml2.model.Transition;
 import org.apache.commons.scxml2.model.TransitionTarget;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link org.apache.commons.scxml2.env.AbstractSCXMLListener}.
@@ -42,7 +42,7 @@ public class AbstractSCXMLListenerTest {
     /**
      * Set up instance variables required by this test case.
      */
-    @Before
+    @BeforeEach
     public void setUp() {
         to = new State();
         from = new State();
@@ -55,7 +55,7 @@ public class AbstractSCXMLListenerTest {
     /**
      * Tear down instance variables required by this test case.
      */
-    @After
+    @AfterEach
     public void tearDown() {
         to = null;
         from = null;
@@ -91,15 +91,15 @@ public class AbstractSCXMLListenerTest {
                 }
             };
 
-        Assert.assertFalse("heardOnEntry == false", heardOnEntry);
-        Assert.assertFalse("heardOnExit == false", heardOnExit);
-        Assert.assertFalse("heardOnTransition == false", heardOnTransition);
+        Assertions.assertFalse(heardOnEntry, "heardOnEntry == false");
+        Assertions.assertFalse(heardOnExit, "heardOnExit == false");
+        Assertions.assertFalse(heardOnTransition, "heardOnTransition == false");
         listener0.onEntry(to);
         listener0.onExit(to);
         listener0.onTransition(from, to, transition, null);
-        Assert.assertTrue("heardOnEntry", heardOnEntry);
-        Assert.assertTrue("heardOnExit", heardOnExit);
-        Assert.assertTrue("heardOnTransition", heardOnTransition);
+        Assertions.assertTrue(heardOnEntry, "heardOnEntry");
+        Assertions.assertTrue(heardOnExit, "heardOnExit");
+        Assertions.assertTrue(heardOnTransition, "heardOnTransition");
     }
 
     @Test
@@ -122,15 +122,15 @@ public class AbstractSCXMLListenerTest {
                 }
             };
 
-        Assert.assertFalse("heardOnEntry == false", heardOnEntry);
-        Assert.assertFalse("heardOnExit == false", heardOnExit);
-        Assert.assertFalse("heardOnTransition == false", heardOnTransition);
+        Assertions.assertFalse(heardOnEntry, "heardOnEntry == false");
+        Assertions.assertFalse(heardOnExit, "heardOnExit == false");
+        Assertions.assertFalse(heardOnTransition, "heardOnTransition == false");
         listener1.onEntry(to);
         listener1.onExit(to);
         listener1.onTransition(from, to, transition, null);
-        Assert.assertTrue("heardOnEntry", heardOnEntry);
-        Assert.assertTrue("heardOnExit", heardOnExit);
-        Assert.assertFalse("heardOnTransition == false", heardOnTransition);
+        Assertions.assertTrue(heardOnEntry, "heardOnEntry");
+        Assertions.assertTrue(heardOnExit, "heardOnExit");
+        Assertions.assertFalse(heardOnTransition, "heardOnTransition == false");
     }
 
     @Test
@@ -145,15 +145,15 @@ public class AbstractSCXMLListenerTest {
                 }
             };
 
-            Assert.assertFalse("heardOnEntry == false", heardOnEntry);
-            Assert.assertFalse("heardOnExit == false", heardOnExit);
-            Assert.assertFalse("heardOnTransition == false", heardOnTransition);
+            Assertions.assertFalse(heardOnEntry, "heardOnEntry == false");
+            Assertions.assertFalse(heardOnExit, "heardOnExit == false");
+            Assertions.assertFalse(heardOnTransition, "heardOnTransition == false");
         listener2.onEntry(to);
         listener2.onExit(to);
         listener2.onTransition(from, to, transition, null);
-        Assert.assertTrue("heardOnEntry", heardOnEntry);
-        Assert.assertFalse("heardOnExit == false", heardOnExit);
-        Assert.assertFalse("heardOnTransition == false", heardOnTransition);
+        Assertions.assertTrue(heardOnEntry, "heardOnEntry");
+        Assertions.assertFalse(heardOnExit, "heardOnExit == false");
+        Assertions.assertFalse(heardOnTransition, "heardOnTransition == false");
     }
 
     @Test
@@ -162,14 +162,14 @@ public class AbstractSCXMLListenerTest {
                 // empty
             };
 
-            Assert.assertFalse("heardOnEntry == false", heardOnEntry);
-            Assert.assertFalse("heardOnExit == false", heardOnExit);
-            Assert.assertFalse("heardOnTransition == false", heardOnTransition);
+            Assertions.assertFalse(heardOnEntry, "heardOnEntry == false");
+            Assertions.assertFalse(heardOnExit, "heardOnExit == false");
+            Assertions.assertFalse(heardOnTransition, "heardOnTransition == false");
         listener3.onEntry(to);
         listener3.onExit(to);
         listener3.onTransition(from, to, transition, null);
-        Assert.assertFalse("heardOnEntry == false", heardOnEntry);
-        Assert.assertFalse("heardOnExit == false", heardOnExit);
-        Assert.assertFalse("heardOnTransition == false", heardOnTransition);
+        Assertions.assertFalse(heardOnEntry, "heardOnEntry == false");
+        Assertions.assertFalse(heardOnExit, "heardOnExit == false");
+        Assertions.assertFalse(heardOnTransition, "heardOnTransition == false");
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/env/AbstractStateMachineTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/AbstractStateMachineTest.java
@@ -19,8 +19,8 @@ package org.apache.commons.scxml2.env;
 import java.net.URL;
 
 import org.apache.commons.scxml2.model.ModelException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link org.apache.commons.scxml2.env.AbstractStateMachine}.
@@ -35,8 +35,8 @@ public class AbstractStateMachineTest {
         Foo f = new Foo(fooScxmlDocument);
         Bar b = new Bar(barScxmlDocument);
 
-        Assert.assertTrue(f.fooCalled());
-        Assert.assertTrue(b.barCalled());
+        Assertions.assertTrue(f.fooCalled());
+        Assertions.assertTrue(b.barCalled());
     }
 
     private class Foo extends AbstractStateMachine {

--- a/src/test/java/org/apache/commons/scxml2/env/LogUtilsTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/LogUtilsTest.java
@@ -18,8 +18,8 @@ package org.apache.commons.scxml2.env;
 
 import org.apache.commons.scxml2.model.State;
 import org.apache.commons.scxml2.model.Transition;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LogUtilsTest {
 
@@ -28,7 +28,7 @@ public class LogUtilsTest {
         State target = new State();
         target.setId("ID");
         
-        Assert.assertEquals("/ID", LogUtils.getTTPath(target));
+        Assertions.assertEquals("/ID", LogUtils.getTTPath(target));
     }
     
     @Test
@@ -45,7 +45,7 @@ public class LogUtilsTest {
         parent1.setParent(parent2);
         target.setParent(parent1);
         
-        Assert.assertEquals("/parent2/parent1/ID", LogUtils.getTTPath(target));
+        Assertions.assertEquals("/parent2/parent1/ID", LogUtils.getTTPath(target));
     }
     
     @Test
@@ -60,7 +60,7 @@ public class LogUtilsTest {
         transition.setCond("condition");
         transition.setEvent("event happened");
         
-        Assert.assertEquals( "(event = event happened, cond = condition, from = /FROM, to = /TO)",
+        Assertions.assertEquals( "(event = event happened, cond = condition, from = /FROM, to = /TO)",
                                         LogUtils.transToString(targetFrom, targetTo, transition, transition.getEvent()));
     }
 

--- a/src/test/java/org/apache/commons/scxml2/env/SimpleContextTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/SimpleContextTest.java
@@ -19,15 +19,15 @@ package org.apache.commons.scxml2.env;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SimpleContextTest {
 
     private SimpleContext context;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         context = new SimpleContext();
     }
@@ -39,7 +39,7 @@ public class SimpleContextTest {
         
         context.setVars(vars);
         
-        Assert.assertTrue(context.has("key"));
+        Assertions.assertTrue(context.has("key"));
     }
 
     @Test
@@ -49,7 +49,7 @@ public class SimpleContextTest {
         
         context.setVars(vars);
         
-        Assert.assertFalse(context.has("differentKey"));
+        Assertions.assertFalse(context.has("differentKey"));
     }
     
     @Test
@@ -65,7 +65,7 @@ public class SimpleContextTest {
         context.setVars(vars);
         context = new SimpleContext(parentContext, parentVars);
         
-        Assert.assertFalse(context.has("differentKey"));
+        Assertions.assertFalse(context.has("differentKey"));
     }
 
     @Test
@@ -81,14 +81,14 @@ public class SimpleContextTest {
         context.setVars(vars);
         context = new SimpleContext(parentContext, parentVars);
         
-        Assert.assertTrue(context.has("differentKey"));
+        Assertions.assertTrue(context.has("differentKey"));
     }
     
     @Test
     public void testGetNull() {
         Object value = context.get("key");
         
-        Assert.assertNull(value);
+        Assertions.assertNull(value);
     }
     
     @Test
@@ -98,7 +98,7 @@ public class SimpleContextTest {
         
         context.setVars(vars);
         
-        Assert.assertEquals("value", context.get("key"));
+        Assertions.assertEquals("value", context.get("key"));
     }
     
     @Test
@@ -114,7 +114,7 @@ public class SimpleContextTest {
         context.setVars(vars);
         context = new SimpleContext(parentContext, parentVars);
         
-        Assert.assertEquals("differentValue", context.get("differentKey"));
+        Assertions.assertEquals("differentValue", context.get("differentKey"));
     }
     
     @Test
@@ -124,7 +124,7 @@ public class SimpleContextTest {
         
         context.setVars(vars);
         
-        Assert.assertNull(context.get("differentKey"));
+        Assertions.assertNull(context.get("differentKey"));
     }
     
     @Test
@@ -140,7 +140,7 @@ public class SimpleContextTest {
         context.setVars(vars);
         context = new SimpleContext(parentContext, parentVars);
         
-        Assert.assertNull(context.get("reallyDifferentKey"));
+        Assertions.assertNull(context.get("reallyDifferentKey"));
     }
 
     @Test
@@ -152,7 +152,7 @@ public class SimpleContextTest {
         
         context.set("key", "newValue");
         
-        Assert.assertEquals("newValue", context.get("key"));
+        Assertions.assertEquals("newValue", context.get("key"));
     }
 
     @Test
@@ -162,7 +162,7 @@ public class SimpleContextTest {
         
         context.set("key", "newValue");
         
-        Assert.assertEquals("newValue", context.get("key"));
+        Assertions.assertEquals("newValue", context.get("key"));
     }
     
     @Test
@@ -180,7 +180,7 @@ public class SimpleContextTest {
         
         context.set("differentKey", "newValue");
         
-        Assert.assertEquals("newValue", context.get("differentKey"));
+        Assertions.assertEquals("newValue", context.get("differentKey"));
     }
 
     @Test
@@ -191,7 +191,7 @@ public class SimpleContextTest {
         SimpleContext parentContext = new SimpleContext(rootEffectiveContext);
         try {
             new EffectiveContextMap(parentContext);
-            Assert.fail("Nested EffectiveContextMap wrapping should fail");
+            Assertions.fail("Nested EffectiveContextMap wrapping should fail");
         }
         catch (IllegalArgumentException e) {
             // good
@@ -205,11 +205,11 @@ public class SimpleContextTest {
         SimpleContext parentContext = new SimpleContext(rootContext);
         parentContext.setLocal("key", "parent");
         SimpleContext effectiveContext = new SimpleContext(parentContext, new EffectiveContextMap(parentContext));
-        Assert.assertEquals("parent", effectiveContext.get("key"));
+        Assertions.assertEquals("parent", effectiveContext.get("key"));
         // ensure EffectiveContextMap provides complete local variable shadowing
         for (Map.Entry<String,Object> entry : effectiveContext.getVars().entrySet()) {
             if (entry.getKey().equals("key")) {
-                Assert.assertEquals("parent", entry.getValue());
+                Assertions.assertEquals("parent", entry.getValue());
             }
         }
     }

--- a/src/test/java/org/apache/commons/scxml2/env/StopWatchTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/StopWatchTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.commons.scxml2.env;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class StopWatchTest {
 
@@ -28,7 +28,7 @@ public class StopWatchTest {
     /**
      * Set up instance variables required by this test case.
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         stopWatch = new StopWatch();
     }
@@ -36,24 +36,24 @@ public class StopWatchTest {
     /**
      * Tear down instance variables required by this test case.
      */
-    @After
+    @AfterEach
     public void tearDown() {
         stopWatch = null;
     }
 
     @Test
     public void testStopWatch() {
-        Assert.assertEquals("reset", stopWatch.getCurrentState());
+        Assertions.assertEquals("reset", stopWatch.getCurrentState());
         stopWatch.fireEvent(StopWatch.EVENT_START);
-        Assert.assertEquals("running", stopWatch.getCurrentState());
+        Assertions.assertEquals("running", stopWatch.getCurrentState());
         stopWatch.fireEvent(StopWatch.EVENT_SPLIT);
-        Assert.assertEquals("paused", stopWatch.getCurrentState());
+        Assertions.assertEquals("paused", stopWatch.getCurrentState());
         stopWatch.fireEvent(StopWatch.EVENT_UNSPLIT);
-        Assert.assertEquals("running", stopWatch.getCurrentState());
+        Assertions.assertEquals("running", stopWatch.getCurrentState());
         stopWatch.fireEvent(StopWatch.EVENT_STOP);
-        Assert.assertEquals("stopped", stopWatch.getCurrentState());
+        Assertions.assertEquals("stopped", stopWatch.getCurrentState());
         stopWatch.fireEvent(StopWatch.EVENT_RESET);
-        Assert.assertEquals("reset", stopWatch.getCurrentState());
+        Assertions.assertEquals("reset", stopWatch.getCurrentState());
     }
 
 }

--- a/src/test/java/org/apache/commons/scxml2/env/groovy/GroovyClosureTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/groovy/GroovyClosureTest.java
@@ -23,8 +23,8 @@ import org.apache.commons.scxml2.SCXMLExecutor;
 import org.apache.commons.scxml2.SCXMLTestHelper;
 import org.apache.commons.scxml2.model.EnterableState;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class GroovyClosureTest {
 
@@ -34,8 +34,8 @@ public class GroovyClosureTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor(groovyClosure, new GroovyEvaluator(true));
         exec.go();
         Set<EnterableState> currentStates = SCXMLTestHelper.fireEvent(exec, "turn_on");
-        Assert.assertEquals(2, currentStates.size());
+        Assertions.assertEquals(2, currentStates.size());
         String id = currentStates.iterator().next().getId();
-        Assert.assertTrue(id.equals("closed") || id.equals("cooking"));
+        Assertions.assertTrue(id.equals("closed") || id.equals("cooking"));
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/env/groovy/GroovyContextTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/groovy/GroovyContextTest.java
@@ -19,15 +19,15 @@ package org.apache.commons.scxml2.env.groovy;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class GroovyContextTest {
 
     @Test
     public void testNew() {
         GroovyContext ctx = new GroovyContext();
-        Assert.assertNotNull(ctx);
+        Assertions.assertNotNull(ctx);
     }
     
     @Test
@@ -35,20 +35,20 @@ public class GroovyContextTest {
         Map<String, Object> m = new HashMap<>();
         m.put("foo", "bar");
         GroovyContext ctx = new GroovyContext(null, m, null);
-        Assert.assertNotNull(ctx);
-        Assert.assertEquals(1, ctx.getVars().size());
+        Assertions.assertNotNull(ctx);
+        Assertions.assertEquals(1, ctx.getVars().size());
         String fooValue = (String) ctx.get("foo");
-        Assert.assertEquals("bar", fooValue);
+        Assertions.assertEquals("bar", fooValue);
     }
     
     @Test
     public void testSetVars() {
         GroovyContext ctx = new GroovyContext();
-        Assert.assertNotNull(ctx);
+        Assertions.assertNotNull(ctx);
         ctx.set("foo", "bar");
-        Assert.assertEquals(1, ctx.getVars().size());
+        Assertions.assertEquals(1, ctx.getVars().size());
         String fooValue = (String) ctx.get("foo");
-        Assert.assertEquals("bar", fooValue);
+        Assertions.assertEquals("bar", fooValue);
     }
 
 }

--- a/src/test/java/org/apache/commons/scxml2/env/groovy/GroovyEvaluatorTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/groovy/GroovyEvaluatorTest.java
@@ -23,16 +23,16 @@ import org.apache.commons.scxml2.SCXMLSystemContext;
 import org.apache.commons.scxml2.StateConfiguration;
 import org.apache.commons.scxml2.Status;
 import org.apache.commons.scxml2.model.State;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class GroovyEvaluatorTest {
 
     private static final String BAD_EXPRESSION = ">";
     private Context ctx;
 
-    @Before
+    @BeforeEach
     public void before() {
         ctx = new GroovyContext(new SCXMLSystemContext(new GroovyContext()), null);
     }
@@ -40,13 +40,13 @@ public class GroovyEvaluatorTest {
     @Test
     public void testEval() throws SCXMLExpressionException {
         Evaluator eval = new GroovyEvaluator();
-        Assert.assertEquals(2, eval.eval(ctx, "1 + 1"));
+        Assertions.assertEquals(2, eval.eval(ctx, "1 + 1"));
     }
 
     @Test
     public void testPristine() throws SCXMLExpressionException {
         Evaluator eval = new GroovyEvaluator();
-        Assert.assertTrue(eval.evalCond(ctx, "1 + 1 == 2"));
+        Assertions.assertTrue(eval.evalCond(ctx, "1 + 1 == 2"));
     }
 
     @Test
@@ -59,7 +59,7 @@ public class GroovyEvaluatorTest {
         State state1 = new State();
         state1.setId("state1");
         stateConfiguration.enterState(state1);
-        Assert.assertTrue(eval.evalCond(ctx, "In('state1')"));
+        Assertions.assertTrue(eval.evalCond(ctx, "In('state1')"));
     }
 
     @Test
@@ -73,29 +73,29 @@ public class GroovyEvaluatorTest {
             "} else {\n" +
                 "y = 2;\n" +
             "}";
-        Assert.assertEquals(2, eval.evalScript(ctx, script));
-        Assert.assertEquals(2, ctx.get("y"));
+        Assertions.assertEquals(2, eval.evalScript(ctx, script));
+        Assertions.assertEquals(2, ctx.get("y"));
     }
 
     @Test
     public void testErrorMessage() {
         Evaluator eval = new GroovyEvaluator();
-        Assert.assertNotNull(eval);
+        Assertions.assertNotNull(eval);
         try {
             eval.eval(ctx, BAD_EXPRESSION);
-            Assert.fail("GroovyEvaluator should throw SCXMLExpressionException");
+            Assertions.fail("GroovyEvaluator should throw SCXMLExpressionException");
         } catch (SCXMLExpressionException e) {
-            Assert.assertTrue("GroovyEvaluator: Incorrect error message",
-                e.getMessage().startsWith("eval('" + BAD_EXPRESSION + "'):"));
+            Assertions.assertTrue(e.getMessage().startsWith("eval('" + BAD_EXPRESSION + "'):"),
+                    "GroovyEvaluator: Incorrect error message");
         }
     }
 
     @Test
     public void testPreprocessScript() {
         GroovyEvaluator evaluator = new GroovyEvaluator();
-        Assert.assertEquals("x &&  x || x  !  x == x <  x <= x != x >  x >= x", evaluator.getScriptPreProcessor().
+        Assertions.assertEquals("x &&  x || x  !  x == x <  x <= x != x >  x >= x", evaluator.getScriptPreProcessor().
                 preProcess("x and x or x not x eq x lt x le x ne x gt x ge x"));
-        Assert.assertEquals("and x OR x\n ! \nx\n== x < \nx(le)x ne. xgt x ge", evaluator.getScriptPreProcessor().
+        Assertions.assertEquals("and x OR x\n ! \nx\n== x < \nx(le)x ne. xgt x ge", evaluator.getScriptPreProcessor().
                  preProcess("and x OR x\nnot\nx\neq x lt\nx(le)x ne. xgt x ge"));
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/env/groovy/SerializableInitialBaseScriptTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/groovy/SerializableInitialBaseScriptTest.java
@@ -22,8 +22,8 @@ import java.util.Set;
 import org.apache.commons.scxml2.SCXMLExecutor;
 import org.apache.commons.scxml2.SCXMLTestHelper;
 import org.apache.commons.scxml2.model.EnterableState;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link org.apache.commons.scxml2.SCXMLExecutor}.
@@ -40,11 +40,11 @@ public class SerializableInitialBaseScriptTest {
     	SCXMLExecutor exec = SCXMLTestHelper.getExecutor(scxml, new GroovyEvaluator(true));
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("state1", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("state1", currentStates.iterator().next().getId());
         exec = SCXMLTestHelper.testInstanceSerializability(exec);
         currentStates = SCXMLTestHelper.fireEvent(exec, "foo.bar.baz");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("state4", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("state4", currentStates.iterator().next().getId());
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/env/groovy/StaticMethodTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/groovy/StaticMethodTest.java
@@ -21,8 +21,8 @@ import java.util.Set;
 import org.apache.commons.scxml2.SCXMLExecutor;
 import org.apache.commons.scxml2.SCXMLTestHelper;
 import org.apache.commons.scxml2.model.EnterableState;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class StaticMethodTest {
 
@@ -32,7 +32,7 @@ public class StaticMethodTest {
         exec.getRootContext().set("System", System.class);
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("static", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("static", currentStates.iterator().next().getId());
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/env/javascript/JSContextTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/javascript/JSContextTest.java
@@ -18,8 +18,8 @@
 package org.apache.commons.scxml2.env.javascript;
 
 import org.apache.commons.scxml2.env.SimpleContext;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for the JSContext SCXML Context implementation for
@@ -33,7 +33,7 @@ public class JSContextTest {
          */
         @Test
         public void testDefaultConstructor() {
-            Assert.assertNotNull("Error in JSContext default constructor",new JSContext());
+            Assertions.assertNotNull(new JSContext(), "Error in JSContext default constructor");
         }
 
         /**
@@ -42,7 +42,7 @@ public class JSContextTest {
          */
         @Test
         public void testChildConstructor() {
-                Assert.assertNotNull("Error in JSContext child constructor",new JSContext(new SimpleContext()));
+                Assertions.assertNotNull(new JSContext(new SimpleContext()), "Error in JSContext child constructor");
         }
 }
 

--- a/src/test/java/org/apache/commons/scxml2/env/javascript/JSContextTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/javascript/JSContextTest.java
@@ -27,26 +27,6 @@ import org.junit.Test;
  *
  */
 public class JSContextTest {
-        // TEST CONSTANTS
-
-        // TEST VARIABLES
-
-        // TEST SETUP
-
-        // CLASS METHODS
-
-        /**
-         * Standalone test runtime.
-         *
-         */
-        public static void main(String args[]) {
-            String[] testCaseName = {JSContextTest.class.getName()};
-
-            junit.textui.TestRunner.main(testCaseName);
-        }
-
-        // INSTANCE METHOD TESTS
-
         /**
          * Tests implementation of JSContext default constructor.
          *
@@ -64,6 +44,5 @@ public class JSContextTest {
         public void testChildConstructor() {
                 Assert.assertNotNull("Error in JSContext child constructor",new JSContext(new SimpleContext()));
         }
-
 }
 

--- a/src/test/java/org/apache/commons/scxml2/env/javascript/JSContextTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/javascript/JSContextTest.java
@@ -22,7 +22,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * JUnit 3 test case for the JSContext SCXML Context implementation for
+ * Test case for the JSContext SCXML Context implementation for
  * the Javascript expression evaluator.
  *
  */

--- a/src/test/java/org/apache/commons/scxml2/env/javascript/JSEvaluatorTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/javascript/JSEvaluatorTest.java
@@ -30,8 +30,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-/** JUnit 3 test case for the JSEvaluator expression evaluator
- *  class. Includes basic tests for:
+/** Test case for the JSEvaluator expression evaluator class.
+ *  Includes basic tests for:
  *  <ul>
  *  <li> constructor
  *  <li> simple standard Javascript expressions

--- a/src/test/java/org/apache/commons/scxml2/env/javascript/JSEvaluatorTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/javascript/JSEvaluatorTest.java
@@ -26,9 +26,9 @@ import org.apache.commons.scxml2.SCXMLExecutor;
 import org.apache.commons.scxml2.SCXMLExpressionException;
 import org.apache.commons.scxml2.SCXMLTestHelper;
 import org.apache.commons.scxml2.io.SCXMLReader;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Test case for the JSEvaluator expression evaluator class.
  *  Includes basic tests for:
@@ -104,7 +104,7 @@ public class JSEvaluatorTest {
      * Creates and initialises an SCXML data model in the context.
      *
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         SCXMLExecutor fsm = SCXMLTestHelper.getExecutor(SCXMLReader.read(new StringReader(SCRIPT)));
         fsm.go();
@@ -123,8 +123,8 @@ public class JSEvaluatorTest {
     public void testBasic() throws SCXMLExpressionException {
         Evaluator evaluator = new JSEvaluator();
 
-        Assert.assertNotNull(evaluator);
-        Assert.assertTrue   ((Boolean) evaluator.eval(context, "1+1 == 2"));
+        Assertions.assertNotNull(evaluator);
+        Assertions.assertTrue   ((Boolean) evaluator.eval(context, "1+1 == 2"));
     }
 
     @Test
@@ -138,8 +138,8 @@ public class JSEvaluatorTest {
             "} else {\n" +
                 "y = 2.0;\n" +
             "}";
-        Assert.assertEquals(2.0, evaluator.evalScript(context, script));
-        Assert.assertEquals(2.0, context.get("y"));
+        Assertions.assertEquals(2.0, evaluator.evalScript(context, script));
+        Assertions.assertEquals(2.0, context.get("y"));
     }
 
     /**
@@ -150,15 +150,15 @@ public class JSEvaluatorTest {
     public void testIllegalExpresssion() {
         Evaluator evaluator = new JSEvaluator();
 
-        Assert.assertNotNull(evaluator);
+        Assertions.assertNotNull(evaluator);
 
         try {
             evaluator.eval(context,BAD_EXPRESSION);
-            Assert.fail          ("JSEvaluator should throw SCXMLExpressionException");
+            Assertions.fail          ("JSEvaluator should throw SCXMLExpressionException");
 
         } catch (SCXMLExpressionException x) {
-            Assert.assertTrue("JSEvaluator: Incorrect error message",
-                       x.getMessage().startsWith("eval('" + BAD_EXPRESSION + "')"));
+            Assertions.assertTrue(x.getMessage().startsWith("eval('" + BAD_EXPRESSION + "')"),
+                    "JSEvaluator: Incorrect error message");
         }
     }
 
@@ -171,13 +171,13 @@ public class JSEvaluatorTest {
         for (TestItem item: SIMPLE_EXPRESSIONS) {
             Object eval = evaluator.eval(context,item.expression);
             if (item.result instanceof Integer && eval instanceof Number) {
-                Assert.assertEquals("Invalid result: " + item.expression,
-                        ((Integer) item.result).intValue(),
-                        ((Number) eval).intValue());
+                Assertions.assertEquals(((Integer) item.result).intValue(),
+                        ((Number) eval).intValue(),
+                        "Invalid result: " + item.expression);
             } else {
-                Assert.assertEquals("Invalid result: " + item.expression,
-                        item.result,
-                        eval);
+                Assertions.assertEquals(item.result,
+                        eval,
+                        "Invalid result: " + item.expression);
             }
         }
     }
@@ -191,11 +191,11 @@ public class JSEvaluatorTest {
         context.set("fibonacci", 12.0);
 
         for (TestItem item: VAR_EXPRESSIONS) {
-            Assert.assertNotNull(context.get("fibonacci"));
-            Assert.assertEquals (12.0,context.get("fibonacci"));
-            Assert.assertEquals ("Invalid result: " + item.expression,
-                          item.result,
-                          evaluator.eval(context,item.expression));
+            Assertions.assertNotNull(context.get("fibonacci"));
+            Assertions.assertEquals (12.0,context.get("fibonacci"));
+            Assertions.assertEquals(item.result,
+                    evaluator.eval(context,item.expression),
+                    "Invalid result: " + item.expression);
         }
     }
 
@@ -207,9 +207,9 @@ public class JSEvaluatorTest {
     public void testInvalidVarExpressions() {
         for (TestItem item: VAR_EXPRESSIONS) {
             try {
-                Assert.assertNull    (context.get("fibonacci"));
+                Assertions.assertNull    (context.get("fibonacci"));
                 evaluator.eval(context,item.expression);
-                Assert.fail          ("Evaluated invalid <var... expression: " + item.expression);
+                Assertions.fail          ("Evaluated invalid <var... expression: " + item.expression);
 
             } catch (SCXMLExpressionException x) {
                 // expected, ignore
@@ -223,9 +223,9 @@ public class JSEvaluatorTest {
      */    
     @Test
     public void testDataModelExpressions() throws Exception {
-        Assert.assertEquals("Invalid result: " + "forest.tree.branch.twig",
-                     "leaf",
-                     evaluator.eval(context,"forest.tree.branch.twig"));
+        Assertions.assertEquals("leaf",
+                     evaluator.eval(context,"forest.tree.branch.twig"),
+                "Invalid result: " + "forest.tree.branch.twig");
     }
 
     /**
@@ -234,11 +234,11 @@ public class JSEvaluatorTest {
      */    
     @Test
     public void testInvalidDataModelExpressions() {
-        Assert.assertNull(context.get("forestx"));
+        Assertions.assertNull(context.get("forestx"));
 
         try {
             evaluator.eval(context,"forestx.tree.branch.twig");
-            Assert.fail          ("Evaluated invalid DataModel expression: " + "forestx.tree.branch.twig");
+            Assertions.fail          ("Evaluated invalid DataModel expression: " + "forestx.tree.branch.twig");
 
         } catch (SCXMLExpressionException x) {
             // expected, ignore
@@ -251,11 +251,11 @@ public class JSEvaluatorTest {
      */    
     @Test
     public void testDataModelLocations() throws Exception {
-        Assert.assertTrue("Invalid result: forest instanceof Map",
-                evaluator.eval(context, "forest") instanceof Map);
+        Assertions.assertTrue(evaluator.eval(context, "forest") instanceof Map,
+                "Invalid result: forest instanceof Map");
 
-        Assert.assertTrue("Invalid result: forest.tree.branch.twig instanceof String",
-                evaluator.eval(context, "forest.tree.branch.twig") instanceof String);
+        Assertions.assertTrue(evaluator.eval(context, "forest.tree.branch.twig") instanceof String,
+                "Invalid result: forest.tree.branch.twig instanceof String");
     }
 
     /**
@@ -264,9 +264,9 @@ public class JSEvaluatorTest {
      */    
     @Test
     public void testInvalidDataModelLocations() throws Exception {
-            Assert.assertNotNull(context.get("forest"));
-            Assert.assertNull("Invalid result: " + "forest.tree.branch.twigx",
-                       evaluator.eval(context,"forest.tree.branch.twigx"));
+            Assertions.assertNotNull(context.get("forest"));
+            Assertions.assertNull(evaluator.eval(context,"forest.tree.branch.twigx"),
+                    "Invalid result: " + "forest.tree.branch.twigx");
     }
 
     /**
@@ -276,8 +276,8 @@ public class JSEvaluatorTest {
     @Test
     public void testScriptFunctions() throws Exception {
         context.set("FIVE", 5);
-        Assert.assertEquals(5,context.get("FIVE"));
-        Assert.assertEquals("Invalid function result", 120.0,evaluator.eval(context,FUNCTION));
+        Assertions.assertEquals(5,context.get("FIVE"));
+        Assertions.assertEquals(120.0, evaluator.eval(context,FUNCTION), "Invalid function result");
     }
 
 

--- a/src/test/java/org/apache/commons/scxml2/env/javascript/JSEvaluatorTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/javascript/JSEvaluatorTest.java
@@ -112,18 +112,6 @@ public class JSEvaluatorTest {
         context = fsm.getGlobalContext();
     }
 
-    // CLASS METHODS
-
-    /**
-     * Standalone test runtime.
-     *
-     */
-    public static void main(String args[]) {
-        String[] testCaseName = {JSEvaluatorTest.class.getName()};
-
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
     // INSTANCE METHOD TESTS
 
     /**

--- a/src/test/java/org/apache/commons/scxml2/env/javascript/JSExampleTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/javascript/JSExampleTest.java
@@ -33,8 +33,8 @@ import org.apache.commons.scxml2.model.EnterableState;
 import org.apache.commons.scxml2.model.ModelException;
 import org.apache.commons.scxml2.model.SCXML;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * SCXML application for the example JavaScript scripts.
@@ -53,8 +53,8 @@ public class JSExampleTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor(scxml);
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("end", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("end", currentStates.iterator().next().getId());
     }
 
     // INNER CLASSES

--- a/src/test/java/org/apache/commons/scxml2/env/javascript/JavaScriptEngineTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/javascript/JavaScriptEngineTest.java
@@ -18,17 +18,17 @@ package org.apache.commons.scxml2.env.javascript;
 
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.commons.scxml2.SCXMLSystemContext;
 import org.apache.commons.scxml2.StateConfiguration;
 import org.apache.commons.scxml2.Status;
 import org.apache.commons.scxml2.model.Final;
 import org.apache.commons.scxml2.system.EventVariable;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class JavaScriptEngineTest {
 
@@ -37,7 +37,7 @@ public class JavaScriptEngineTest {
     private JSContext _systemContext;
     private JSContext context;
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
         evaluator = new JSEvaluator();
         _systemContext = new JSContext();

--- a/src/test/java/org/apache/commons/scxml2/env/jexl/ForeachTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/jexl/ForeachTest.java
@@ -18,8 +18,8 @@ package org.apache.commons.scxml2.env.jexl;
 
 import org.apache.commons.scxml2.SCXMLExecutor;
 import org.apache.commons.scxml2.SCXMLTestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Simple test for SCXML <foreach/>
@@ -30,6 +30,6 @@ public class ForeachTest {
     public void testForeach() throws Exception {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/env/jexl/foreach.xml");
         exec.go();
-        Assert.assertTrue(exec.getStatus().isFinal());
+        Assertions.assertTrue(exec.getStatus().isFinal());
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/env/jexl/JexlContextTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/jexl/JexlContextTest.java
@@ -19,15 +19,15 @@ package org.apache.commons.scxml2.env.jexl;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class JexlContextTest {
 
     @Test
     public void testNew() {
         JexlContext ctx = new JexlContext();
-        Assert.assertNotNull(ctx);
+        Assertions.assertNotNull(ctx);
     }
     
     @Test
@@ -35,10 +35,10 @@ public class JexlContextTest {
         Map<String, Object> m = new HashMap<>();
         m.put("foo", "bar");
         JexlContext ctx = new JexlContext(null, m);
-        Assert.assertNotNull(ctx);
-        Assert.assertEquals(1, ctx.getVars().size());
+        Assertions.assertNotNull(ctx);
+        Assertions.assertEquals(1, ctx.getVars().size());
         String fooValue = (String) ctx.get("foo");
-        Assert.assertEquals("bar", fooValue);
+        Assertions.assertEquals("bar", fooValue);
     }
 
 }

--- a/src/test/java/org/apache/commons/scxml2/env/jexl/JexlEvaluatorTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/jexl/JexlEvaluatorTest.java
@@ -19,8 +19,8 @@ package org.apache.commons.scxml2.env.jexl;
 import org.apache.commons.scxml2.Context;
 import org.apache.commons.scxml2.Evaluator;
 import org.apache.commons.scxml2.SCXMLExpressionException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class JexlEvaluatorTest {
 
@@ -30,7 +30,7 @@ public class JexlEvaluatorTest {
     @Test
     public void testPristine() throws SCXMLExpressionException {
         Evaluator eval = new JexlEvaluator();
-        Assert.assertTrue((Boolean) eval.eval(ctx, "1+1 eq 2"));
+        Assertions.assertTrue((Boolean) eval.eval(ctx, "1+1 eq 2"));
     }
 
     @Test
@@ -44,20 +44,20 @@ public class JexlEvaluatorTest {
             "} else {\n" +
                 "y = 2;\n" +
             "}";
-        Assert.assertEquals(2, eval.evalScript(ctx, script));
-        Assert.assertEquals(2, ctx.get("y"));
+        Assertions.assertEquals(2, eval.evalScript(ctx, script));
+        Assertions.assertEquals(2, ctx.get("y"));
     }
 
     @Test
     public void testErrorMessage() {
         Evaluator eval = new JexlEvaluator();
-        Assert.assertNotNull(eval);
+        Assertions.assertNotNull(eval);
         try {
             eval.eval(ctx, BAD_EXPRESSION);
-            Assert.fail("JexlEvaluator should throw SCXMLExpressionException");
+            Assertions.fail("JexlEvaluator should throw SCXMLExpressionException");
         } catch (SCXMLExpressionException e) {
-            Assert.assertTrue("JexlEvaluator: Incorrect error message",
-                e.getMessage().startsWith("eval('" + BAD_EXPRESSION + "'):"));
+            Assertions.assertTrue(e.getMessage().startsWith("eval('" + BAD_EXPRESSION + "'):"),
+                    "JexlEvaluator: Incorrect error message");
         }
     }
 

--- a/src/test/java/org/apache/commons/scxml2/env/jexl/StaticMethodTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/jexl/StaticMethodTest.java
@@ -22,8 +22,8 @@ import org.apache.commons.scxml2.SCXMLExecutor;
 import org.apache.commons.scxml2.SCXMLTestHelper;
 import org.apache.commons.scxml2.model.EnterableState;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class StaticMethodTest {
 
@@ -33,8 +33,8 @@ public class StaticMethodTest {
         exec.getRootContext().set("System", System.class);
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("static", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("static", currentStates.iterator().next().getId());
     }
 
 }

--- a/src/test/java/org/apache/commons/scxml2/invoke/InvokeParamNameTest.java
+++ b/src/test/java/org/apache/commons/scxml2/invoke/InvokeParamNameTest.java
@@ -24,10 +24,10 @@ import org.apache.commons.scxml2.SCXMLTestHelper;
 import org.apache.commons.scxml2.TriggerEvent;
 import org.apache.commons.scxml2.EventBuilder;
 import org.apache.commons.scxml2.model.ModelException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 // Tests for 4.3.1 in WD-scxml-20080516
 public class InvokeParamNameTest {
@@ -37,14 +37,14 @@ public class InvokeParamNameTest {
     private static String lastURL;
     private static Map<String, Object> lastParams;
     
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/invoke/invoker-04.xml");
         exec.registerInvokerClass("x-test", DummyInvoker.class);
         exec.go();
     }
     
-    @After
+    @AfterEach
     public void tearDown() {
         exec.unregisterInvokerClass("x-test");    
     }
@@ -59,11 +59,11 @@ public class InvokeParamNameTest {
     @Test
     public void testNameAndExpr() throws Exception {
         trigger();
-        Assert.assertTrue(lastURL.endsWith("TestSrc"));
+        Assertions.assertTrue(lastURL.endsWith("TestSrc"));
         final Map.Entry<String, Object> e =
             lastParams.entrySet().iterator().next();
-        Assert.assertEquals("ding", e.getKey());
-        Assert.assertEquals("foo", e.getValue());
+        Assertions.assertEquals("ding", e.getKey());
+        Assertions.assertEquals("foo", e.getValue());
     }
 
     // Tests "param" element with a "name" attribute and "expr" attribute locating a data id
@@ -71,9 +71,9 @@ public class InvokeParamNameTest {
     public void testSoleNameLocation() throws Exception {
         trigger(); trigger();
         final Map m = (Map)lastParams.values().iterator().next();
-        Assert.assertNotNull(m);
-        Assert.assertEquals("bar", m.keySet().iterator().next());
-        Assert.assertEquals("foo", m.get("bar"));
+        Assertions.assertNotNull(m);
+        Assertions.assertEquals("bar", m.keySet().iterator().next());
+        Assertions.assertEquals("foo", m.get("bar"));
     }
 
     public static class DummyInvoker implements Invoker {

--- a/src/test/java/org/apache/commons/scxml2/invoke/InvokeTest.java
+++ b/src/test/java/org/apache/commons/scxml2/invoke/InvokeTest.java
@@ -25,8 +25,8 @@ import org.apache.commons.scxml2.env.SimpleErrorReporter;
 import org.apache.commons.scxml2.io.SCXMLReader;
 import org.apache.commons.scxml2.model.EnterableState;
 import org.apache.commons.scxml2.model.SCXML;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link org.apache.commons.scxml2.SCXMLExecutor}.
@@ -45,8 +45,8 @@ public class InvokeTest {
         exec.registerInvokerClass("scxml", SimpleSCXMLInvoker.class);
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("invoker", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("invoker", currentStates.iterator().next().getId());
     }
     
     @Test
@@ -57,7 +57,7 @@ public class InvokeTest {
         exec.registerInvokerClass("scxml", SimpleSCXMLInvoker.class);
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
+        Assertions.assertEquals(1, currentStates.size());
     }
     
     @Test
@@ -68,7 +68,7 @@ public class InvokeTest {
         exec.registerInvokerClass("scxml", SimpleSCXMLInvoker.class);
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
+        Assertions.assertEquals(1, currentStates.size());
         SCXMLTestHelper.fireEvent(exec, "s1.next");
         SCXMLTestHelper.fireEvent(exec, "state1.next");
     }

--- a/src/test/java/org/apache/commons/scxml2/io/ContentParserTest.java
+++ b/src/test/java/org/apache/commons/scxml2/io/ContentParserTest.java
@@ -22,34 +22,34 @@ import java.util.LinkedHashMap;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ContentParserTest {
 
     @Test
     public void testTrimContent() throws Exception {
-        Assert.assertEquals(null, ContentParser.trimContent(null));
-        Assert.assertEquals("", ContentParser.trimContent(""));
-        Assert.assertEquals("", ContentParser.trimContent(" "));
-        Assert.assertEquals("", ContentParser.trimContent("  "));
-        Assert.assertEquals("", ContentParser.trimContent("   "));
-        Assert.assertEquals("", ContentParser.trimContent("\t\n\r"));
-        Assert.assertEquals("a", ContentParser.trimContent("a"));
-        Assert.assertEquals("a", ContentParser.trimContent(" a"));
-        Assert.assertEquals("a", ContentParser.trimContent("a "));
-        Assert.assertEquals("a", ContentParser.trimContent(" a "));
+        Assertions.assertEquals(null, ContentParser.trimContent(null));
+        Assertions.assertEquals("", ContentParser.trimContent(""));
+        Assertions.assertEquals("", ContentParser.trimContent(" "));
+        Assertions.assertEquals("", ContentParser.trimContent("  "));
+        Assertions.assertEquals("", ContentParser.trimContent("   "));
+        Assertions.assertEquals("", ContentParser.trimContent("\t\n\r"));
+        Assertions.assertEquals("a", ContentParser.trimContent("a"));
+        Assertions.assertEquals("a", ContentParser.trimContent(" a"));
+        Assertions.assertEquals("a", ContentParser.trimContent("a "));
+        Assertions.assertEquals("a", ContentParser.trimContent(" a "));
     }
 
     @Test
     public void testSpaceNormalizeContent() throws Exception {
-        Assert.assertEquals(null, ContentParser.spaceNormalizeContent(null));
-        Assert.assertEquals("", ContentParser.spaceNormalizeContent(""));
-        Assert.assertEquals("a", ContentParser.spaceNormalizeContent("a"));
-        Assert.assertEquals("a", ContentParser.spaceNormalizeContent(" a"));
-        Assert.assertEquals("a", ContentParser.spaceNormalizeContent("a "));
-        Assert.assertEquals("a", ContentParser.spaceNormalizeContent(" a "));
-        Assert.assertEquals("a b c", ContentParser.spaceNormalizeContent("  a\tb \n \r c  "));
+        Assertions.assertEquals(null, ContentParser.spaceNormalizeContent(null));
+        Assertions.assertEquals("", ContentParser.spaceNormalizeContent(""));
+        Assertions.assertEquals("a", ContentParser.spaceNormalizeContent("a"));
+        Assertions.assertEquals("a", ContentParser.spaceNormalizeContent(" a"));
+        Assertions.assertEquals("a", ContentParser.spaceNormalizeContent("a "));
+        Assertions.assertEquals("a", ContentParser.spaceNormalizeContent(" a "));
+        Assertions.assertEquals("a b c", ContentParser.spaceNormalizeContent("  a\tb \n \r c  "));
     }
 
     @Test
@@ -68,12 +68,12 @@ public class ContentParserTest {
         jsonObject.put("int", 1);
         jsonObject.put("boolean", Boolean.FALSE);
         jsonObject.put("null", null);
-        Assert.assertEquals(jsonObject, contentParser.parseJson(jsonObjectString));
+        Assertions.assertEquals(jsonObject, contentParser.parseJson(jsonObjectString));
 
         String jsonArrayString = "[" + jsonObjectString + "," + "# yaml comment\n" + jsonObjectString+"]";
         ArrayList<Object> jsonArray = new ArrayList<>(2);
         jsonArray.add(jsonObject);
         jsonArray.add(jsonObject);
-        Assert.assertEquals(jsonArray, contentParser.parseJson(jsonArrayString));
+        Assertions.assertEquals(jsonArray, contentParser.parseJson(jsonArrayString));
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/io/SCXMLReaderTest.java
+++ b/src/test/java/org/apache/commons/scxml2/io/SCXMLReaderTest.java
@@ -47,11 +47,11 @@ import org.apache.commons.scxml2.model.SCXML;
 import org.apache.commons.scxml2.model.Send;
 import org.apache.commons.scxml2.model.State;
 import org.apache.commons.scxml2.model.Transition;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link org.apache.commons.scxml2.io.SCXMLReader}.
@@ -62,13 +62,13 @@ public class SCXMLReaderTest {
 
     private Log scxmlReaderLog;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         oldLogFactoryProperty = System.getProperty(LogFactory.FACTORY_PROPERTY);
         System.setProperty(LogFactory.FACTORY_PROPERTY, RecordingLogFactory.class.getName());
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         if (oldLogFactoryProperty == null) {
             System.clearProperty(LogFactory.FACTORY_PROPERTY);
@@ -80,7 +80,7 @@ public class SCXMLReaderTest {
     /**
      * Set up instance variables required by this test case.
      */
-    @Before
+    @BeforeEach
     public void before() {
         scxmlReaderLog = LogFactory.getLog(SCXMLReader.class);
         clearRecordedLogMessages();
@@ -92,61 +92,61 @@ public class SCXMLReaderTest {
     @Test
     public void testSCXMLReaderMicrowave03Sample() throws Exception {
         SCXML scxml = SCXMLTestHelper.parse("org/apache/commons/scxml2/env/jexl/microwave-03.xml");
-        Assert.assertNotNull(scxml);
-        Assert.assertNotNull(serialize(scxml));
+        Assertions.assertNotNull(scxml);
+        Assertions.assertNotNull(serialize(scxml));
     }
     
     @Test
     public void testSCXMLReaderMicrowave04Sample() throws Exception {
         SCXML scxml = SCXMLTestHelper.parse("org/apache/commons/scxml2/env/jexl/microwave-04.xml");
-        Assert.assertNotNull(scxml);
-        Assert.assertNotNull(serialize(scxml));
+        Assertions.assertNotNull(scxml);
+        Assertions.assertNotNull(serialize(scxml));
     }
     
     @Test
     public void testSCXMLReaderTransitions01Sample() throws Exception {
         SCXML scxml = SCXMLTestHelper.parse("org/apache/commons/scxml2/transitions-01.xml");
-        Assert.assertNotNull(scxml);
-        Assert.assertNotNull(serialize(scxml));
+        Assertions.assertNotNull(scxml);
+        Assertions.assertNotNull(serialize(scxml));
     }
     
     @Test
     public void testSCXMLReaderPrefix01Sample() throws Exception {
         SCXML scxml = SCXMLTestHelper.parse("org/apache/commons/scxml2/prefix-01.xml");
-        Assert.assertNotNull(scxml);
-        Assert.assertNotNull(serialize(scxml));
+        Assertions.assertNotNull(scxml);
+        Assertions.assertNotNull(serialize(scxml));
     }
     
     @Test
     public void testSCXMLReaderSend01Sample() throws Exception {
         SCXML scxml = SCXMLTestHelper.parse("org/apache/commons/scxml2/send-01.xml");
         State ten = (State) scxml.getInitialTransition().getTargets().iterator().next();
-        Assert.assertEquals("ten", ten.getId());
+        Assertions.assertEquals("ten", ten.getId());
         List<Transition> ten_done = ten.getTransitionsList("done.state.ten");
-        Assert.assertEquals(1, ten_done.size());
+        Assertions.assertEquals(1, ten_done.size());
         Transition ten2twenty = ten_done.get(0);
         List<Action> actions = ten2twenty.getActions();
-        Assert.assertEquals(1, actions.size());
+        Assertions.assertEquals(1, actions.size());
         Send send = (Send) actions.get(0);
-        Assert.assertEquals("send1", send.getId());
+        Assertions.assertEquals("send1", send.getId());
         /* Serialize
         scxmlAsString = serialize(scxml);
-        Assert.assertNotNull(scxmlAsString);
+        Assertions.assertNotNull(scxmlAsString);
         String expectedFoo2Serialization =
             "<foo xmlns=\"http://my.test.namespace\" id=\"foo2\">"
             + "<prompt xmlns=\"http://foo.bar.com/vxml3\">This is just"
             + " an example.</prompt></foo>";
-        Assert.assertFalse(scxmlAsString.indexOf(expectedFoo2Serialization) == -1);
+        Assertions.assertFalse(scxmlAsString.indexOf(expectedFoo2Serialization) == -1);
         */
     }
     
     @Test
     public void testSCXMLReaderInitialAttr() throws Exception {
         SCXML scxml = SCXMLTestHelper.parse("org/apache/commons/scxml2/io/scxml-initial-attr.xml");
-        Assert.assertNotNull(scxml);
-        Assert.assertNotNull(serialize(scxml));
+        Assertions.assertNotNull(scxml);
+        Assertions.assertNotNull(serialize(scxml));
         Final foo = (Final) scxml.getInitialTransition().getTargets().iterator().next();
-        Assert.assertEquals("foo", foo.getId());
+        Assertions.assertEquals("foo", foo.getId());
     }
 
     @Test
@@ -155,16 +155,18 @@ public class SCXMLReaderTest {
         SCXMLTestHelper.parse(SCXMLTestHelper.getResource("org/apache/commons/scxml2/io/scxml-valid-transition-targets-test.xml"));
     }
 
-    @Test(expected=org.apache.commons.scxml2.model.ModelException.class)
-    public void testSCXMLInValidTransitionTargets1() throws Exception {
+    @Test
+    public void testSCXMLInValidTransitionTargets1() {
         // ModelUpdater will fail on invalid transition targets
-        SCXMLTestHelper.parse(SCXMLTestHelper.getResource("org/apache/commons/scxml2/io/scxml-invalid-transition-targets-test1.xml"));
+        Assertions.assertThrows(org.apache.commons.scxml2.model.ModelException.class,
+                () -> SCXMLTestHelper.parse(SCXMLTestHelper.getResource("org/apache/commons/scxml2/io/scxml-invalid-transition-targets-test1.xml")));
     }
 
-    @Test(expected=org.apache.commons.scxml2.model.ModelException.class)
-    public void testSCXMLInValidTransitionTargets2() throws Exception {
+    @Test
+    public void testSCXMLInValidTransitionTargets2() {
         // ModelUpdater will fail on invalid transition targets
-        SCXMLTestHelper.parse(SCXMLTestHelper.getResource("org/apache/commons/scxml2/io/scxml-invalid-transition-targets-test2.xml"));
+        Assertions.assertThrows(org.apache.commons.scxml2.model.ModelException.class,
+                () -> SCXMLTestHelper.parse(SCXMLTestHelper.getResource("org/apache/commons/scxml2/io/scxml-invalid-transition-targets-test2.xml")));
     }
 
     @Test
@@ -175,12 +177,12 @@ public class SCXMLReaderTest {
         cas.add(ca);
         SCXML scxml = SCXMLTestHelper.parse("org/apache/commons/scxml2/io/custom-action-body-test-1.xml", cas);
         EnterableState state = (EnterableState) scxml.getInitialTransition().getTargets().iterator().next();
-        Assert.assertEquals("actions", state.getId());
+        Assertions.assertEquals("actions", state.getId());
         List<Action> actions = state.getOnEntries().get(0).getActions();
-        Assert.assertEquals(1, actions.size());
+        Assertions.assertEquals(1, actions.size());
         MyAction my = (MyAction)((CustomActionWrapper)actions.get(0)).getAction();
-        Assert.assertNotNull(my);
-        Assert.assertTrue(my.getParsedValue() != null);
+        Assertions.assertNotNull(my);
+        Assertions.assertTrue(my.getParsedValue() != null);
     }
 
     @Test
@@ -190,15 +192,15 @@ public class SCXMLReaderTest {
         Configuration configuration = new Configuration();
         SCXML scxml = SCXMLReader.read(SCXMLTestHelper.getResource("org/apache/commons/scxml2/io/scxml-with-invalid-elems.xml"),
                         configuration);
-        Assert.assertNotNull(scxml);
-        Assert.assertNotNull(serialize(scxml));
+        Assertions.assertNotNull(scxml);
+        Assertions.assertNotNull(serialize(scxml));
         Final foo = (Final) scxml.getInitialTransition().getTargets().iterator().next();
-        Assert.assertEquals("foo", foo.getId());
+        Assertions.assertEquals("foo", foo.getId());
         Datamodel dataModel = scxml.getDatamodel();
-        Assert.assertNotNull(dataModel);
+        Assertions.assertNotNull(dataModel);
         List<Data> dataList = dataModel.getData();
-        Assert.assertEquals(1, dataList.size());
-        Assert.assertEquals("time", dataList.get(0).getId());
+        Assertions.assertEquals(1, dataList.size());
+        Assertions.assertEquals("time", dataList.get(0).getId());
         assertContainsRecordedLogMessage("Ignoring unknown or invalid element <baddata> in namespace \"http://www.w3.org/2005/07/scxml\" as child of <datamodel>");
         assertContainsRecordedLogMessage("Ignoring unknown or invalid element <baddata> in namespace \"http://www.example.com/scxml\" as child of <datamodel>");
         assertContainsRecordedLogMessage("Ignoring unknown or invalid element <trace> in namespace \"http://www.w3.org/2005/07/scxml\" as child of <onentry>");
@@ -212,15 +214,15 @@ public class SCXMLReaderTest {
         configuration.setSilent(true);
         SCXMLReader.read(SCXMLTestHelper.getResource("org/apache/commons/scxml2/io/scxml-with-invalid-elems.xml"),
                 configuration);
-        Assert.assertNotNull(scxml);
-        Assert.assertNotNull(serialize(scxml));
+        Assertions.assertNotNull(scxml);
+        Assertions.assertNotNull(serialize(scxml));
         foo = (Final) scxml.getInitialTransition().getTargets().iterator().next();
-        Assert.assertEquals("foo", foo.getId());
+        Assertions.assertEquals("foo", foo.getId());
         dataModel = scxml.getDatamodel();
-        Assert.assertNotNull(dataModel);
+        Assertions.assertNotNull(dataModel);
         dataList = dataModel.getData();
-        Assert.assertEquals(1, dataList.size());
-        Assert.assertEquals("time", dataList.get(0).getId());
+        Assertions.assertEquals(1, dataList.size());
+        Assertions.assertEquals("time", dataList.get(0).getId());
         assertNotContainsRecordedLogMessage("Ignoring unknown or invalid element <baddata> in namespace \"http://www.w3.org/2005/07/scxml\" as child of <datamodel>");
         assertNotContainsRecordedLogMessage("Ignoring unknown or invalid element <baddata> in namespace \"http://www.example.com/scxml\" as child of <datamodel>");
         assertNotContainsRecordedLogMessage("Ignoring unknown or invalid element <trace> in namespace \"http://www.w3.org/2005/07/scxml\" as child of <onentry>");
@@ -235,9 +237,9 @@ public class SCXMLReaderTest {
         try {
             SCXMLReader.read(SCXMLTestHelper.getResource("org/apache/commons/scxml2/io/scxml-with-invalid-elems.xml"),
                     configuration);
-            Assert.fail("In strict mode, it should have thrown a model exception.");
+            Assertions.fail("In strict mode, it should have thrown a model exception.");
         } catch (ModelException e) {
-            Assert.assertTrue(e.getMessage().contains("Ignoring unknown or invalid element <baddata>"));
+            Assertions.assertTrue(e.getMessage().contains("Ignoring unknown or invalid element <baddata>"));
         }
 
         assertContainsRecordedLogMessage("Ignoring unknown or invalid element <baddata> in namespace \"http://www.w3.org/2005/07/scxml\" as child of <datamodel>");
@@ -255,9 +257,9 @@ public class SCXMLReaderTest {
         try {
             scxml = SCXMLReader.read(SCXMLTestHelper.getResource("org/apache/commons/scxml2/io/scxml-with-invalid-elems.xml"),
                     configuration);
-            Assert.fail("In strict mode, it should have thrown a model exception.");
+            Assertions.fail("In strict mode, it should have thrown a model exception.");
         } catch (ModelException e) {
-            Assert.assertTrue(e.getMessage().contains("Ignoring unknown or invalid element <baddata>"));
+            Assertions.assertTrue(e.getMessage().contains("Ignoring unknown or invalid element <baddata>"));
         }
         assertNotContainsRecordedLogMessage("Ignoring unknown or invalid element <baddata> in namespace \"http://www.w3.org/2005/07/scxml\" as child of <datamodel>");
         assertNotContainsRecordedLogMessage("Ignoring unknown or invalid element <baddata> in namespace \"http://www.example.com/scxml\" as child of <datamodel>");
@@ -268,21 +270,22 @@ public class SCXMLReaderTest {
     @Test
     public void testSCXMLReaderGroovyClosure() throws Exception {
         SCXML scxml = SCXMLTestHelper.parse("org/apache/commons/scxml2/env/groovy/groovy-closure.xml");
-        Assert.assertNotNull(scxml);
-        Assert.assertNotNull(scxml.getGlobalScript());
+        Assertions.assertNotNull(scxml);
+        Assertions.assertNotNull(scxml.getGlobalScript());
         String scxmlAsString = serialize(scxml);
-        Assert.assertNotNull(scxmlAsString);
+        Assertions.assertNotNull(scxmlAsString);
         scxml = SCXMLTestHelper.parse(new StringReader(scxmlAsString), null);
-        Assert.assertNotNull(scxml);
-        Assert.assertNotNull(scxml.getGlobalScript());
+        Assertions.assertNotNull(scxml);
+        Assertions.assertNotNull(scxml.getGlobalScript());
     }
 
-    @Test(expected=org.apache.commons.scxml2.model.ModelException.class)
-    public void dataWithSrcAndExprIsRejectedInStrictConfiguration() throws Exception {
+    @Test
+    public void dataWithSrcAndExprIsRejectedInStrictConfiguration() {
         Configuration configuration = new Configuration();
         configuration.setStrict(true);
         configuration.setSilent(true);
-        SCXMLReader.read(getClass().getResourceAsStream("data-with-src-and-expr.xml"), configuration);
+        Assertions.assertThrows(org.apache.commons.scxml2.model.ModelException.class,
+                () -> SCXMLReader.read(getClass().getResourceAsStream("data-with-src-and-expr.xml"), configuration));
     }
 
     @Test
@@ -291,54 +294,54 @@ public class SCXMLReaderTest {
         configuration.setStrict(false);
         configuration.setSilent(true);
         SCXML scxml = SCXMLReader.read(getClass().getResourceAsStream("data-with-src-and-expr.xml"), configuration);
-        Assert.assertNotNull(scxml);
-        Assert.assertNotNull(scxml.getDatamodel());
-        Assert.assertNotNull(scxml.getDatamodel().getData());
-        Assert.assertEquals("Exactly one data element parsed.", 1, scxml.getDatamodel().getData().size());
+        Assertions.assertNotNull(scxml);
+        Assertions.assertNotNull(scxml.getDatamodel());
+        Assertions.assertNotNull(scxml.getDatamodel().getData());
+        Assertions.assertEquals(1, scxml.getDatamodel().getData().size(), "Exactly one data element parsed.");
         Data data = scxml.getDatamodel().getData().get(0);
-        Assert.assertNotNull(data);
-        Assert.assertEquals("'an expression'", data.getExpr());
+        Assertions.assertNotNull(data);
+        Assertions.assertEquals("'an expression'", data.getExpr());
     }
 
     @Test
     public void srcAttributeOfDataIsParsed() throws Exception {
         SCXML scxml = SCXMLTestHelper.parse("org/apache/commons/scxml2/io/data-with-src.xml");
-        Assert.assertNotNull(scxml);
-        Assert.assertNotNull(scxml.getDatamodel());
-        Assert.assertNotNull(scxml.getDatamodel().getData());
-        Assert.assertEquals("Exactly one data element parsed.", 1, scxml.getDatamodel().getData().size());
+        Assertions.assertNotNull(scxml);
+        Assertions.assertNotNull(scxml.getDatamodel());
+        Assertions.assertNotNull(scxml.getDatamodel().getData());
+        Assertions.assertEquals(1, scxml.getDatamodel().getData().size(), "Exactly one data element parsed.");
         Data data = scxml.getDatamodel().getData().get(0);
-        Assert.assertNotNull(data);
-        Assert.assertEquals("http://www.w3.org/TR/sxcml", data.getSrc());
+        Assertions.assertNotNull(data);
+        Assertions.assertEquals("http://www.w3.org/TR/sxcml", data.getSrc());
     }
 
     @Test
     public void exprAttributeOfDataIsParsed() throws Exception {
         SCXML scxml = SCXMLTestHelper.parse("org/apache/commons/scxml2/io/data-with-expr.xml");
-        Assert.assertNotNull(scxml);
-        Assert.assertNotNull(scxml.getDatamodel());
-        Assert.assertNotNull(scxml.getDatamodel().getData());
-        Assert.assertEquals("Exactly one data element parsed.", 1, scxml.getDatamodel().getData().size());
+        Assertions.assertNotNull(scxml);
+        Assertions.assertNotNull(scxml.getDatamodel());
+        Assertions.assertNotNull(scxml.getDatamodel().getData());
+        Assertions.assertEquals(1, scxml.getDatamodel().getData().size(), "Exactly one data element parsed.");
         Data data = scxml.getDatamodel().getData().get(0);
-        Assert.assertNotNull(data);
-        Assert.assertEquals("'an expression'", data.getExpr());
+        Assertions.assertNotNull(data);
+        Assertions.assertEquals("'an expression'", data.getExpr());
     }
 
     private String serialize(final SCXML scxml) throws IOException, XMLStreamException {
         String scxmlAsString = SCXMLWriter.write(scxml);
-        Assert.assertNotNull(scxmlAsString);
+        Assertions.assertNotNull(scxmlAsString);
         return scxmlAsString;
     }
 
     private void assertContainsRecordedLogMessage(final String message) {
         if (scxmlReaderLog instanceof RecordingSimpleLog) {
-            Assert.assertTrue(((RecordingSimpleLog) scxmlReaderLog).containsMessage(message));
+            Assertions.assertTrue(((RecordingSimpleLog) scxmlReaderLog).containsMessage(message));
         }
     }
 
     private void assertNotContainsRecordedLogMessage(final String message) {
         if (scxmlReaderLog instanceof RecordingSimpleLog) {
-            Assert.assertFalse(((RecordingSimpleLog) scxmlReaderLog).containsMessage(message));
+            Assertions.assertFalse(((RecordingSimpleLog) scxmlReaderLog).containsMessage(message));
         }
     }
 

--- a/src/test/java/org/apache/commons/scxml2/io/SCXMLRequiredAttributesTest.java
+++ b/src/test/java/org/apache/commons/scxml2/io/SCXMLRequiredAttributesTest.java
@@ -22,11 +22,11 @@ import org.apache.commons.scxml2.SCXMLExecutor;
 import org.apache.commons.scxml2.SCXMLTestHelper;
 import org.apache.commons.scxml2.model.ModelException;
 import org.apache.commons.scxml2.model.SCXML;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test enforcement of required SCXML element attributes, spec https://www.w3.org/TR/2015/REC-scxml-20150901

--- a/src/test/java/org/apache/commons/scxml2/io/SCXMLWriterTest.java
+++ b/src/test/java/org/apache/commons/scxml2/io/SCXMLWriterTest.java
@@ -25,8 +25,8 @@ import org.apache.commons.scxml2.model.Parallel;
 import org.apache.commons.scxml2.model.SCXML;
 import org.apache.commons.scxml2.model.Script;
 import org.apache.commons.scxml2.model.State;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -52,7 +52,7 @@ public class SCXMLWriterTest {
             + "version=\"version1\" initial=\"off\"><!--http://commons.apache.org/scxml--><state></state>"
             + "</scxml>";
 
-        Assert.assertEquals(assertValue, SCXMLWriter.write(scxml, new SCXMLWriter.Configuration(true, false)));
+        Assertions.assertEquals(assertValue, SCXMLWriter.write(scxml, new SCXMLWriter.Configuration(true, false)));
     }
     
     @Test
@@ -71,7 +71,7 @@ public class SCXMLWriterTest {
             + "xmlns:cs=\"http://commons.apache.org/scxml\" version=\"1.0\" initial=\"S1\">"
             + "<!--http://commons.apache.org/scxml--><state id=\"S1\"></state></scxml>";
 
-        Assert.assertEquals(assertValue, SCXMLWriter.write(scxml, new SCXMLWriter.Configuration(true, false)));
+        Assertions.assertEquals(assertValue, SCXMLWriter.write(scxml, new SCXMLWriter.Configuration(true, false)));
     }
     
     @Test
@@ -119,7 +119,7 @@ public class SCXMLWriterTest {
             + "</parallel>"
             + "</scxml>";
 
-        Assert.assertEquals(assertValue, SCXMLWriter.write(scxml, new SCXMLWriter.Configuration(true, false)));
+        Assertions.assertEquals(assertValue, SCXMLWriter.write(scxml, new SCXMLWriter.Configuration(true, false)));
      }
 
     @Test
@@ -143,6 +143,6 @@ public class SCXMLWriterTest {
                 + "xmlns:cs=\"http://commons.apache.org/scxml\" version=\"1.0\" initial=\"S1\">"
                 + "<!--http://commons.apache.org/scxml--><script><![CDATA[foo=\"abc\"]]></script><state id=\"S1\"></state></scxml>";
 
-        Assert.assertEquals(assertValue, SCXMLWriter.write(scxml, new SCXMLWriter.Configuration(true, false)));
+        Assertions.assertEquals(assertValue, SCXMLWriter.write(scxml, new SCXMLWriter.Configuration(true, false)));
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/io/StateSrcTest.java
+++ b/src/test/java/org/apache/commons/scxml2/io/StateSrcTest.java
@@ -22,8 +22,8 @@ import org.apache.commons.scxml2.SCXMLExecutor;
 import org.apache.commons.scxml2.SCXMLTestHelper;
 import org.apache.commons.scxml2.model.EnterableState;
 import org.apache.commons.scxml2.model.ModelException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 /**
  * Test white box nature of <state> element "src" attribute.
  */
@@ -34,22 +34,22 @@ public class StateSrcTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/io/src-test-1.xml");
         exec.go();
         Set<EnterableState> states = exec.getStatus().getStates();
-        Assert.assertEquals(1, states.size());
-        Assert.assertEquals("srctest3", states.iterator().next().getId());
+        Assertions.assertEquals(1, states.size());
+        Assertions.assertEquals("srctest3", states.iterator().next().getId());
         states = SCXMLTestHelper.fireEvent(exec, "src.test");
-        Assert.assertEquals(1, states.size());
-        Assert.assertEquals("srctest1end", states.iterator().next().getId());
-        Assert.assertTrue(exec.getStatus().isFinal());
+        Assertions.assertEquals(1, states.size());
+        Assertions.assertEquals("srctest1end", states.iterator().next().getId());
+        Assertions.assertTrue(exec.getStatus().isFinal());
     }
     
     @Test
     public void testBadSrcInclude() throws Exception {
         try {
             SCXMLReader.read(SCXMLTestHelper.getResource("org/apache/commons/scxml2/io/src-test-4.xml"));
-            Assert.fail("Document with bad <state> src attribute shouldn't be parsed!");
+            Assertions.fail("Document with bad <state> src attribute shouldn't be parsed!");
         } catch (ModelException me) {
-            Assert.assertTrue("Unexpected error message for bad <state> 'src' URI",
-                me.getMessage() != null && me.getMessage().contains("Source attribute in <state src="));
+            Assertions.assertTrue(me.getMessage() != null && me.getMessage().contains("Source attribute in <state src="),
+                    "Unexpected error message for bad <state> 'src' URI");
         }
     }
     
@@ -57,10 +57,10 @@ public class StateSrcTest {
     public void testBadSrcFragmentInclude() throws Exception {
         try {
             SCXMLReader.read(SCXMLTestHelper.getResource("org/apache/commons/scxml2/io/src-test-5.xml"));
-            Assert.fail("Document with bad <state> src attribute shouldn't be parsed!");
+            Assertions.fail("Document with bad <state> src attribute shouldn't be parsed!");
         } catch (ModelException me) {
-            Assert.assertTrue("Unexpected error message for bad <state> 'src' URI fragment",
-                me.getMessage() != null && me.getMessage().contains("URI Fragment in <state src="));
+            Assertions.assertTrue(me.getMessage() != null && me.getMessage().contains("URI Fragment in <state src="),
+                    "Unexpected error message for bad <state> 'src' URI fragment");
         }
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/issues/Issue112Test.java
+++ b/src/test/java/org/apache/commons/scxml2/issues/Issue112Test.java
@@ -29,9 +29,9 @@ import org.apache.commons.scxml2.model.Action;
 import org.apache.commons.scxml2.model.CustomAction;
 import org.apache.commons.scxml2.model.ModelException;
 import org.apache.commons.scxml2.model.SCXML;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for issue 112.
@@ -42,7 +42,7 @@ public class Issue112Test {
     /**
      * Tear down instance variables required by this test case.
      */
-    @After
+    @AfterEach
     public void tearDown() {
         Application.QUEUE.clear();
     }
@@ -60,7 +60,7 @@ public class Issue112Test {
         SCXML scxml = SCXMLTestHelper.parse("org/apache/commons/scxml2/issues/queue-01.xml", customActions);
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor(scxml);
         exec.go();
-        Assert.assertEquals("init", exec.getStatus().getStates().
+        Assertions.assertEquals("init", exec.getStatus().getStates().
                 iterator().next().getId());
 
         // Add an event, other external events could be added to the queue at any time (this test only adds one).
@@ -76,8 +76,8 @@ public class Issue112Test {
             }
         }
 
-        Assert.assertTrue(exec.getStatus().isFinal());
-        Assert.assertEquals("end", exec.getStatus().getStates().
+        Assertions.assertTrue(exec.getStatus().isFinal());
+        Assertions.assertEquals("end", exec.getStatus().getStates().
                 iterator().next().getId());
 
     }

--- a/src/test/java/org/apache/commons/scxml2/issues/Issue62Test.java
+++ b/src/test/java/org/apache/commons/scxml2/issues/Issue62Test.java
@@ -22,8 +22,8 @@ import org.apache.commons.scxml2.SCXMLExecutor;
 import org.apache.commons.scxml2.SCXMLTestHelper;
 import org.apache.commons.scxml2.model.EnterableState;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for issue 62.
@@ -36,8 +36,8 @@ public class Issue62Test {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/issues/issue62-01.xml");
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("s1.1", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("s1.1", currentStates.iterator().next().getId());
         SCXMLTestHelper.assertPostTriggerState(exec, "foo", "s1.1");
     }
     
@@ -57,12 +57,12 @@ public class Issue62Test {
 
     private void fragmenttest(SCXMLExecutor exec) throws Exception {
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("s1", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("s1", currentStates.iterator().next().getId());
         SCXMLTestHelper.assertPostTriggerState(exec, "foo", "e1.1.1");
         SCXMLTestHelper.assertPostTriggerState(exec, "bar", "e1.1.2");
         SCXMLTestHelper.assertPostTriggerState(exec, "baz", "s3");
-        Assert.assertTrue(exec.getStatus().isFinal());
+        Assertions.assertTrue(exec.getStatus().isFinal());
     }
 }
 

--- a/src/test/java/org/apache/commons/scxml2/issues/Issue64Test.java
+++ b/src/test/java/org/apache/commons/scxml2/issues/Issue64Test.java
@@ -18,7 +18,7 @@ package org.apache.commons.scxml2.issues;
 
 import org.apache.commons.scxml2.SCXMLExecutor;
 import org.apache.commons.scxml2.SCXMLTestHelper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for issue 64.

--- a/src/test/java/org/apache/commons/scxml2/model/ActionTest.java
+++ b/src/test/java/org/apache/commons/scxml2/model/ActionTest.java
@@ -16,15 +16,15 @@
  */
 package org.apache.commons.scxml2.model;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ActionTest {
 
     private Action action;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         action = new Assign();
     }
@@ -40,7 +40,7 @@ public class ActionTest {
 
         TransitionTarget returnValue = action.getParentEnterableState();
         
-        Assert.assertEquals("on", returnValue.getId());
+        Assertions.assertEquals("on", returnValue.getId());
     }
     
     @Test
@@ -60,7 +60,7 @@ public class ActionTest {
 
         TransitionTarget returnValue = action.getParentEnterableState();
         
-        Assert.assertEquals("on", returnValue.getId());
+        Assertions.assertEquals("on", returnValue.getId());
     }
     
     @Test
@@ -80,7 +80,7 @@ public class ActionTest {
 
         TransitionTarget returnValue = action.getParentEnterableState();
         
-        Assert.assertEquals("off", returnValue.getId());
+        Assertions.assertEquals("off", returnValue.getId());
     }
     
     @Test
@@ -99,6 +99,6 @@ public class ActionTest {
 
         TransitionTarget returnValue = action.getParentEnterableState();
 
-        Assert.assertEquals("off", returnValue.getId());
+        Assertions.assertEquals("off", returnValue.getId());
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/model/ActionsTest.java
+++ b/src/test/java/org/apache/commons/scxml2/model/ActionsTest.java
@@ -19,8 +19,8 @@ package org.apache.commons.scxml2.model;
 import org.apache.commons.scxml2.Context;
 import org.apache.commons.scxml2.SCXMLExecutor;
 import org.apache.commons.scxml2.SCXMLTestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 /**
  * Unit tests {@link org.apache.commons.scxml2.model.Assign}.
  * Unit tests {@link org.apache.commons.scxml2.model.Cancel}.
@@ -56,9 +56,8 @@ public class ActionsTest {
 
     private void runTest(SCXMLExecutor exec) {
         Context ctx = SCXMLTestHelper.lookupContext(exec, "actionsTest");
-        Assert.assertEquals(ctx.get("foo"), "foobar");
-        Assert.assertEquals("Missed event transition",
-            true, ctx.get("eventsent"));
+        Assertions.assertEquals(ctx.get("foo"), "foobar");
+        Assertions.assertEquals(true, ctx.get("eventsent"), "Missed event transition");
     }
 }
 

--- a/src/test/java/org/apache/commons/scxml2/model/AssignTest.java
+++ b/src/test/java/org/apache/commons/scxml2/model/AssignTest.java
@@ -20,8 +20,8 @@ import java.util.Set;
 
 import org.apache.commons.scxml2.SCXMLExecutor;
 import org.apache.commons.scxml2.SCXMLTestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 /**
  * Unit tests for &lt;assign&gt; element, particular the "src" attribute.
  */
@@ -32,9 +32,9 @@ public class AssignTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/model/assign-test-01.xml");
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("assign3", currentStates.iterator().next().getId());
-        Assert.assertTrue(exec.getStatus().isFinal());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("assign3", currentStates.iterator().next().getId());
+        Assertions.assertTrue(exec.getStatus().isFinal());
     }
     
     @Test
@@ -42,9 +42,9 @@ public class AssignTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/model/assign-test-02.xml");
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("assign3", currentStates.iterator().next().getId());
-        Assert.assertTrue(exec.getStatus().isFinal());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("assign3", currentStates.iterator().next().getId());
+        Assertions.assertTrue(exec.getStatus().isFinal());
     }
 }
 

--- a/src/test/java/org/apache/commons/scxml2/model/CancelTest.java
+++ b/src/test/java/org/apache/commons/scxml2/model/CancelTest.java
@@ -21,7 +21,7 @@ import org.apache.commons.scxml2.SCXMLTestHelper;
 import org.apache.commons.scxml2.TriggerEvent;
 import org.apache.commons.scxml2.EventBuilder;
 import org.apache.commons.scxml2.env.SimpleDispatcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CancelTest {
 

--- a/src/test/java/org/apache/commons/scxml2/model/CustomActionTest.java
+++ b/src/test/java/org/apache/commons/scxml2/model/CustomActionTest.java
@@ -21,16 +21,16 @@ import java.util.List;
 
 import org.apache.commons.scxml2.SCXMLExecutor;
 import org.apache.commons.scxml2.SCXMLTestHelper;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class CustomActionTest {
 
     /**
      * Set up instance variables required by this test case.
      */
-    @Before
+    @BeforeEach
     public void setUp() {
         Hello.callbacks = 0;
     }
@@ -45,7 +45,7 @@ public class CustomActionTest {
     public void testAddBadCustomAction01() {
         try {
             new CustomAction(null, "hello", Hello.class);
-            Assert.fail("Added custom action with illegal namespace");
+            Assertions.fail("Added custom action with illegal namespace");
         } catch (IllegalArgumentException iae) {
             // Expected
         }
@@ -55,7 +55,7 @@ public class CustomActionTest {
     public void testAddBadCustomAction02() {
         try {
             new CustomAction("  ", "hello", Hello.class);
-            Assert.fail("Added custom action with illegal namespace");
+            Assertions.fail("Added custom action with illegal namespace");
         } catch (IllegalArgumentException iae) {
             // Expected
         }
@@ -66,7 +66,7 @@ public class CustomActionTest {
         try {
             new CustomAction("http://my.actions.domain/CUSTOM", "",
                 Hello.class);
-            Assert.fail("Added custom action with illegal local name");
+            Assertions.fail("Added custom action with illegal local name");
         } catch (IllegalArgumentException iae) {
             // Expected
         }
@@ -77,7 +77,7 @@ public class CustomActionTest {
         try {
             new CustomAction("http://my.actions.domain/CUSTOM", "  ",
                 Hello.class);
-            Assert.fail("Added custom action with illegal local name");
+            Assertions.fail("Added custom action with illegal local name");
         } catch (IllegalArgumentException iae) {
             // Expected
         }
@@ -88,7 +88,7 @@ public class CustomActionTest {
         try {            
             new CustomAction("http://www.w3.org/2005/07/scxml", "foo",
                 Hello.class);
-            Assert.fail("Added custom action in the SCXML namespace");
+            Assertions.fail("Added custom action in the SCXML namespace");
         } catch (IllegalArgumentException iae) {
             // Expected
         }
@@ -101,9 +101,9 @@ public class CustomActionTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/hello-world.xml");
         exec.go();
         // (2) Single, final state
-        Assert.assertEquals("hello", (exec.getStatus().getStates().
+        Assertions.assertEquals("hello", (exec.getStatus().getStates().
                 iterator().next()).getId());
-        Assert.assertTrue(exec.getStatus().isFinal());
+        Assertions.assertTrue(exec.getStatus().isFinal());
     }
 
     // Hello World example using a custom <hello> action
@@ -128,13 +128,13 @@ public class CustomActionTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor(scxml);
         exec.go();
         // (4) Single, final state
-        Assert.assertEquals("custom", (exec.getStatus().getStates().
+        Assertions.assertEquals("custom", (exec.getStatus().getStates().
                 iterator().next()).getId());
-        Assert.assertTrue(exec.getStatus().isFinal());
+        Assertions.assertTrue(exec.getStatus().isFinal());
 
         // The custom action defined by Hello.class should be called
         // to execute() exactly twice at this point (one by <my:hello/> and the other by <foo:bar/>).
-        Assert.assertEquals(2, Hello.callbacks);
+        Assertions.assertEquals(2, Hello.callbacks);
     }
 
     // Hello World example using custom <my:hello> action
@@ -154,12 +154,12 @@ public class CustomActionTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor(scxml);
         exec.go();
         // (4) Single, final state
-        Assert.assertEquals("custom", (exec.getStatus().getStates().
+        Assertions.assertEquals("custom", (exec.getStatus().getStates().
             iterator().next()).getId());
 
         // The custom action defined by Hello.class should be called
         // to execute() exactly twice at this point (one by <my:hello/> and the other by <my:hello/> in external).
-        Assert.assertEquals(2, Hello.callbacks);
+        Assertions.assertEquals(2, Hello.callbacks);
     }
 
     // Hello World example using custom <my:send> action
@@ -178,12 +178,12 @@ public class CustomActionTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor(scxml);
         exec.go();
         // (4) Single, final state
-        Assert.assertEquals("custom", (exec.getStatus().getStates().
+        Assertions.assertEquals("custom", (exec.getStatus().getStates().
             iterator().next()).getId());
 
         // The custom action defined by Hello.class should be called
         // to execute() exactly once at this point (by <my:send/>).
-        Assert.assertEquals(1, Hello.callbacks);
+        Assertions.assertEquals(1, Hello.callbacks);
     }
 
     // Hello World example using custom <my:hello> action that generates an
@@ -203,30 +203,28 @@ public class CustomActionTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor(scxml);
         exec.go();
         // (4) Single, final state
-        Assert.assertEquals("Invalid intermediate state",
-                     "custom1", (exec.getStatus().getStates().
-                                iterator().next()).getId());
+        Assertions.assertEquals("custom1", exec.getStatus().getStates().iterator().next().getId(),
+                "Invalid intermediate state");
         // (5) Verify datamodel variable is correct
-        Assert.assertEquals("Missing helloName1 in root context", "custom04a",
-                     exec.getGlobalContext().get("helloName1"));
+        Assertions.assertEquals("custom04a", exec.getGlobalContext().get("helloName1"),
+                "Missing helloName1 in root context");
 
         // The custom action defined by Hello.class should be called
         // to execute() exactly once at this point (by onentry in init state).
-        Assert.assertEquals(1, Hello.callbacks);
+        Assertions.assertEquals(1, Hello.callbacks);
 
         // (6) Check use of payload in non-initial state
         SCXMLTestHelper.fireEvent(exec, "custom.next");
         // (7) Verify correct end state
-        Assert.assertEquals("Missing helloName1 in root context", "custom04b",
-                exec.getGlobalContext().get("helloName1"));
-        Assert.assertEquals("Invalid final state",
-                "end", (exec.getStatus().getStates().
-                iterator().next()).getId());
-        Assert.assertTrue(exec.getStatus().isFinal());
+        Assertions.assertEquals("custom04b", exec.getGlobalContext().get("helloName1"),
+                "Missing helloName1 in root context");
+        Assertions.assertEquals("end", exec.getStatus().getStates().iterator().next().getId(),
+                "Invalid final state");
+        Assertions.assertTrue(exec.getStatus().isFinal());
 
         // The custom action defined by Hello.class should be called
         // to execute() exactly two times at this point (by onentry in custom2 state).
-        Assert.assertEquals(2, Hello.callbacks);
+        Assertions.assertEquals(2, Hello.callbacks);
     }
 }
 

--- a/src/test/java/org/apache/commons/scxml2/model/DatamodelTest.java
+++ b/src/test/java/org/apache/commons/scxml2/model/DatamodelTest.java
@@ -22,8 +22,8 @@ import org.apache.commons.scxml2.SCXMLExecutor;
 import org.apache.commons.scxml2.SCXMLTestHelper;
 import org.apache.commons.scxml2.TriggerEvent;
 import org.apache.commons.scxml2.EventBuilder;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 /**
  * Unit tests {@link org.apache.commons.scxml2.SCXMLExecutor}.
  */
@@ -38,7 +38,7 @@ public class DatamodelTest {
         exec01.go();
         SCXMLExecutor exec02 = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/env/jexl/datamodel-01.xml");
         exec02.go();
-        Assert.assertFalse(exec01 == exec02);
+        Assertions.assertFalse(exec01 == exec02);
         runtest(exec01, exec02);
     }
 
@@ -51,7 +51,7 @@ public class DatamodelTest {
         exec01.go();
         SCXMLExecutor exec02 = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/env/groovy/datamodel-01.xml");
         exec02.go();
-        Assert.assertFalse(exec01 == exec02);
+        Assertions.assertFalse(exec01 == exec02);
         runtest(exec01, exec02);
     }
 
@@ -64,7 +64,7 @@ public class DatamodelTest {
         exec01.go();
         SCXMLExecutor exec02 = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/env/javascript/datamodel-01.xml");
         exec02.go();
-        Assert.assertFalse(exec01 == exec02);
+        Assertions.assertFalse(exec01 == exec02);
         runtest(exec01, exec02);
     }
 
@@ -93,36 +93,36 @@ public class DatamodelTest {
         //// Interleaved
         // exec01
         Set<EnterableState> currentStates = exec01.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("ten", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("ten", currentStates.iterator().next().getId());
         exec01 = SCXMLTestHelper.testInstanceSerializability(exec01);
         currentStates = fireEvent("done.state.ten", exec01);
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("twenty", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("twenty", currentStates.iterator().next().getId());
         // exec02
         currentStates = exec02.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("ten", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("ten", currentStates.iterator().next().getId());
         // exec01
         currentStates = fireEvent("done.state.twenty", exec01);
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("thirty", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("thirty", currentStates.iterator().next().getId());
         exec01 = SCXMLTestHelper.testInstanceSerializability(exec01);
         // exec02
         currentStates = fireEvent("done.state.ten", exec02);
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("twenty", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("twenty", currentStates.iterator().next().getId());
         exec02 = SCXMLTestHelper.testInstanceSerializability(exec02);
         currentStates = fireEvent("done.state.twenty", exec02);
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("thirty", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("thirty", currentStates.iterator().next().getId());
         currentStates = fireEvent("done.state.thirty", exec02);
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("forty", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("forty", currentStates.iterator().next().getId());
         // exec01
         currentStates = fireEvent("done.state.thirty", exec01);
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("forty", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("forty", currentStates.iterator().next().getId());
     }
 
     private Set<EnterableState> fireEvent(String name, SCXMLExecutor exec) throws Exception {

--- a/src/test/java/org/apache/commons/scxml2/model/HistoryTest.java
+++ b/src/test/java/org/apache/commons/scxml2/model/HistoryTest.java
@@ -20,8 +20,8 @@ import java.util.Set;
 
 import org.apache.commons.scxml2.SCXMLExecutor;
 import org.apache.commons.scxml2.SCXMLTestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class HistoryTest {
 
@@ -30,7 +30,7 @@ public class HistoryTest {
         History history = new History();
         history.setType("deep");
         
-        Assert.assertTrue(history.isDeep());
+        Assertions.assertTrue(history.isDeep());
     }
         
     @Test
@@ -38,7 +38,7 @@ public class HistoryTest {
         History history = new History();
         history.setType("shallow");
         
-        Assert.assertFalse(history.isDeep());
+        Assertions.assertFalse(history.isDeep());
     }
     
     @Test
@@ -60,14 +60,14 @@ public class HistoryTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/history-default-01.xml");
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("state11", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("state11", currentStates.iterator().next().getId());
         currentStates = SCXMLTestHelper.fireEvent(exec, "state.next");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("state211", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("state211", currentStates.iterator().next().getId());
         currentStates = SCXMLTestHelper.fireEvent(exec, "state.next");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("state31", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("state31", currentStates.iterator().next().getId());
     }
     
     @Test
@@ -75,7 +75,7 @@ public class HistoryTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/history-parallel-01.xml");
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
+        Assertions.assertEquals(1, currentStates.size());
         SCXMLTestHelper.assertState(exec, "off_call");
         SCXMLTestHelper.assertPostTriggerStates(exec, "dial", new String[] { "talking", "on_call" });
         SCXMLTestHelper.assertPostTriggerStates(exec, "consult", new String[] { "consult_talking", "on_consult" });
@@ -90,35 +90,35 @@ public class HistoryTest {
 
     private void runHistoryFlow(SCXMLExecutor exec) throws Exception {
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("phase1", currentStates.iterator().next().getId());
-        Assert.assertEquals("phase1", pauseAndResume(exec));
-        Assert.assertEquals("phase2", nextPhase(exec));
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("phase1", currentStates.iterator().next().getId());
+        Assertions.assertEquals("phase1", pauseAndResume(exec));
+        Assertions.assertEquals("phase2", nextPhase(exec));
         // pause and resume couple of times for good measure
-        Assert.assertEquals("phase2", pauseAndResume(exec));
-        Assert.assertEquals("phase2", pauseAndResume(exec));
-        Assert.assertEquals("phase3", nextPhase(exec));
-        Assert.assertEquals("phase3", pauseAndResume(exec));
+        Assertions.assertEquals("phase2", pauseAndResume(exec));
+        Assertions.assertEquals("phase2", pauseAndResume(exec));
+        Assertions.assertEquals("phase3", nextPhase(exec));
+        Assertions.assertEquals("phase3", pauseAndResume(exec));
         exec.reset();
         currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("phase1", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("phase1", currentStates.iterator().next().getId());
     }
 
     private String pauseAndResume(SCXMLExecutor exec) throws Exception {
         Set<EnterableState> currentStates = SCXMLTestHelper.fireEvent(exec, "flow.pause");
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("interrupted", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("interrupted", currentStates.iterator().next().getId());
         exec = SCXMLTestHelper.testInstanceSerializability(exec);
         currentStates = SCXMLTestHelper.fireEvent(exec, "flow.resume");
-        Assert.assertEquals(1, currentStates.size());
+        Assertions.assertEquals(1, currentStates.size());
         SCXMLTestHelper.testInstanceSerializability(exec);
         return currentStates.iterator().next().getId();
     }
 
     private String nextPhase(SCXMLExecutor exec) throws Exception {
         Set<EnterableState> currentStates = SCXMLTestHelper.fireEvent(exec, "done.state.phase");
-        Assert.assertEquals(1, currentStates.size());
+        Assertions.assertEquals(1, currentStates.size());
         return currentStates.iterator().next().getId();
     }
 

--- a/src/test/java/org/apache/commons/scxml2/model/ParallelTest.java
+++ b/src/test/java/org/apache/commons/scxml2/model/ParallelTest.java
@@ -18,8 +18,8 @@ package org.apache.commons.scxml2.model;
 
 import org.apache.commons.scxml2.SCXMLExecutor;
 import org.apache.commons.scxml2.SCXMLTestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ParallelTest {
 
@@ -44,12 +44,12 @@ public class ParallelTest {
         exec.go();
         SCXMLTestHelper.assertPostTriggerStates(exec, "dummy.event", new String[] { "para11", "para21" });
         Object count = exec.getEvaluator().eval(exec.getGlobalContext(),"root.root.count");
-        Assert.assertEquals(5, count);
+        Assertions.assertEquals(5, count);
         SCXMLTestHelper.assertPostTriggerStates(exec, "foo", new String[]{"para12", "para21"});
         count = exec.getEvaluator().eval(exec.getGlobalContext(),"root.root.count");
-        Assert.assertEquals(7, count);
+        Assertions.assertEquals(7, count);
         SCXMLTestHelper.assertPostTriggerState(exec, "bar", "end");
         count = exec.getEvaluator().eval(exec.getGlobalContext(),"root.root.count");
-        Assert.assertEquals(14, count);
+        Assertions.assertEquals(14, count);
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/model/ScriptTest.java
+++ b/src/test/java/org/apache/commons/scxml2/model/ScriptTest.java
@@ -20,8 +20,8 @@ import java.util.Set;
 
 import org.apache.commons.scxml2.SCXMLExecutor;
 import org.apache.commons.scxml2.SCXMLTestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ScriptTest {
 
@@ -33,8 +33,8 @@ public class ScriptTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/env/jexl/script-01.xml");
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("end", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("end", currentStates.iterator().next().getId());
     }
 
     /**
@@ -45,8 +45,8 @@ public class ScriptTest {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/env/javascript/script-01.xml");
         exec.go();
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("end", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("end", currentStates.iterator().next().getId());
     }
 
 }

--- a/src/test/java/org/apache/commons/scxml2/model/ScxmlInitialAttributeTest.java
+++ b/src/test/java/org/apache/commons/scxml2/model/ScxmlInitialAttributeTest.java
@@ -16,15 +16,15 @@
  */
 package org.apache.commons.scxml2.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.StringReader;
 
 import org.apache.commons.scxml2.SCXMLExecutor;
 import org.apache.commons.scxml2.SCXMLTestHelper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ScxmlInitialAttributeTest {
 
@@ -55,9 +55,9 @@ public class ScxmlInitialAttributeTest {
     @Test
     public void testInitial() throws Exception {
         SCXML scxml = SCXMLTestHelper.parse(new StringReader(SCXML_WITH_LEGAL_INITIAL), null);
-        assertEquals("The initial state ID reading was wrong.", "s1", scxml.getInitial());
+        assertEquals("s1", scxml.getInitial(), "The initial state ID reading was wrong.");
         TransitionTarget tt = scxml.getInitialTransition().getTargets().iterator().next();
-        assertEquals("The initial state resolution was wrong.", "s1", tt.getId());
+        assertEquals("s1", tt.getId(), "The initial state resolution was wrong.");
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor(scxml);
         exec.go();
         assertEquals(scxml.getTargets().get("s1"), exec.getStatus().getStates().iterator().next());
@@ -68,7 +68,7 @@ public class ScxmlInitialAttributeTest {
         SCXML scxml = SCXMLTestHelper.parse(new StringReader(SCXML_WITH_NO_INITIAL), null);
         assertNull(scxml.getInitial());
         TransitionTarget tt = scxml.getInitialTransition().getTargets().iterator().next();
-        assertEquals("The initial state resolution was wrong.", "s1", tt.getId());
+        assertEquals("s1", tt.getId(), "The initial state resolution was wrong.");
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor(scxml);
         exec.go();
         assertEquals(scxml.getTargets().get("s1"), exec.getStatus().getStates().iterator().next());

--- a/src/test/java/org/apache/commons/scxml2/model/SendTest.java
+++ b/src/test/java/org/apache/commons/scxml2/model/SendTest.java
@@ -28,8 +28,8 @@ import org.apache.commons.scxml2.SCXMLTestHelper;
 import org.apache.commons.scxml2.TriggerEvent;
 import org.apache.commons.scxml2.EventBuilder;
 import org.apache.commons.scxml2.env.SimpleDispatcher;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SendTest {
 
@@ -50,19 +50,19 @@ public class SendTest {
         TriggerEvent te = new EventBuilder("event.foo", TriggerEvent.SIGNAL_EVENT).data(3).build();
         SCXMLTestHelper.fireEvent(exec, te);
 
-        Assert.assertFalse("Payloads empty.", payloads.isEmpty());
-        Assert.assertTrue("Payload is not a map.", payloads.get(0) instanceof Map);
+        Assertions.assertFalse(payloads.isEmpty(), "Payloads empty.");
+        Assertions.assertTrue(payloads.get(0) instanceof Map, "Payload is not a map.");
         Map<String, Object> firstPayload = (Map<String, Object>) payloads.get(0);
-        Assert.assertEquals("Only two in the namelist data expected.", 2, firstPayload.size());
+        Assertions.assertEquals(2, firstPayload.size(), "Only two in the namelist data expected.");
 
-        Assert.assertEquals("Unexpected value for 'one'.", 1, firstPayload.get("one"));
-        Assert.assertEquals("Unexpected value for 'two'.", 2, firstPayload.get("two"));
+        Assertions.assertEquals(1, firstPayload.get("one"), "Unexpected value for 'one'.");
+        Assertions.assertEquals(2, firstPayload.get("two"), "Unexpected value for 'two'.");
 
         // Note: the standard allows specifying the value of the namelist attribute of the <send> element
         // as space-separated list of values, which implies an ordered sequence of items.
         final Iterator<String> it = firstPayload.keySet().iterator();
-        Assert.assertEquals("The first one in the namelist must be 'one'.", "one", it.next());
-        Assert.assertEquals("The first one in the namelist must be 'two'.", "two", it.next());
+        Assertions.assertEquals("one", it.next(), "The first one in the namelist must be 'one'.");
+        Assertions.assertEquals("two", it.next(), "The first one in the namelist must be 'two'.");
     }
 
     private long parseDelay(String delayString) throws SCXMLExpressionException {
@@ -71,23 +71,23 @@ public class SendTest {
 
     @Test
     public void testDelayExpression() throws Exception {
-        Assert.assertEquals(0L, parseDelay(".s"));
-        Assert.assertEquals(0L, parseDelay(".0s"));
-        Assert.assertEquals(1000L, parseDelay("1.s"));
-        Assert.assertEquals(1000L, parseDelay("1.0s"));
-        Assert.assertEquals(1500L, parseDelay("1.5s"));
-        Assert.assertEquals(500L, parseDelay(".5s"));
-        Assert.assertEquals(500L, parseDelay("0.5s"));
-        Assert.assertEquals(50L, parseDelay("0.05s"));
-        Assert.assertEquals(5L, parseDelay("0.005s"));
-        Assert.assertEquals(0L, parseDelay("0.0005s"));
-        Assert.assertEquals(0L, parseDelay(".9ms"));
-        Assert.assertEquals(1L, parseDelay("1.9ms"));
-        Assert.assertEquals(60000L, parseDelay("1m"));
-        Assert.assertEquals(60000L, parseDelay("1.0m"));
-        Assert.assertEquals(30000L, parseDelay(".5m"));
-        Assert.assertEquals(6000L, parseDelay(".1m"));
-        Assert.assertEquals(6000L, parseDelay(".10m"));
-        Assert.assertEquals(15000L, parseDelay(".25m"));
+        Assertions.assertEquals(0L, parseDelay(".s"));
+        Assertions.assertEquals(0L, parseDelay(".0s"));
+        Assertions.assertEquals(1000L, parseDelay("1.s"));
+        Assertions.assertEquals(1000L, parseDelay("1.0s"));
+        Assertions.assertEquals(1500L, parseDelay("1.5s"));
+        Assertions.assertEquals(500L, parseDelay(".5s"));
+        Assertions.assertEquals(500L, parseDelay("0.5s"));
+        Assertions.assertEquals(50L, parseDelay("0.05s"));
+        Assertions.assertEquals(5L, parseDelay("0.005s"));
+        Assertions.assertEquals(0L, parseDelay("0.0005s"));
+        Assertions.assertEquals(0L, parseDelay(".9ms"));
+        Assertions.assertEquals(1L, parseDelay("1.9ms"));
+        Assertions.assertEquals(60000L, parseDelay("1m"));
+        Assertions.assertEquals(60000L, parseDelay("1.0m"));
+        Assertions.assertEquals(30000L, parseDelay(".5m"));
+        Assertions.assertEquals(6000L, parseDelay(".1m"));
+        Assertions.assertEquals(6000L, parseDelay(".10m"));
+        Assertions.assertEquals(15000L, parseDelay(".25m"));
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/model/StateTest.java
+++ b/src/test/java/org/apache/commons/scxml2/model/StateTest.java
@@ -20,22 +20,22 @@ import java.util.List;
 
 import org.apache.commons.scxml2.SCXMLExecutor;
 import org.apache.commons.scxml2.SCXMLTestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class StateTest {
 
     @Test
     public void testGetTransitionsListNull() {
         State state = new State();
-        Assert.assertNull(state.getTransitionsList("event"));
+        Assertions.assertNull(state.getTransitionsList("event"));
     }
         
     @Test
     public void testGetTransitionsList() {
         State state = new State();
         state.getTransitionsList().add(new Transition());
-        Assert.assertNotNull(state.getTransitionsList(null));
+        Assertions.assertNotNull(state.getTransitionsList(null));
     }
         
     @Test
@@ -48,8 +48,8 @@ public class StateTest {
         
         List<Transition> events = state.getTransitionsList("event");
         
-        Assert.assertEquals(1, events.size());
-        Assert.assertEquals("event", events.get(0).getEvent());
+        Assertions.assertEquals(1, events.size());
+        Assertions.assertEquals("event", events.get(0).getEvent());
     }
         
     @Test
@@ -66,7 +66,7 @@ public class StateTest {
         
         List<Transition> events = state.getTransitionsList("event");
         
-        Assert.assertEquals(2, events.size());
+        Assertions.assertEquals(2, events.size());
     }
         
     @Test
@@ -83,13 +83,13 @@ public class StateTest {
         
         List<Transition> events = state.getTransitionsList();
         
-        Assert.assertEquals(2, events.size());
+        Assertions.assertEquals(2, events.size());
     }
         
     @Test
     public void testHasHistoryEmpty() {
         State state = new State();
-        Assert.assertFalse(state.hasHistory());
+        Assertions.assertFalse(state.hasHistory());
     }
     
     @Test
@@ -99,13 +99,13 @@ public class StateTest {
         State state = new State();
         state.addHistory(history);
         
-        Assert.assertTrue(state.hasHistory());
+        Assertions.assertTrue(state.hasHistory());
     }
         
     @Test
     public void testIsSimple() {
         State state = new State();
-        Assert.assertTrue(state.isSimple());
+        Assertions.assertTrue(state.isSimple());
     }
         
     @Test
@@ -115,13 +115,13 @@ public class StateTest {
         State state = new State();
         state.addChild(state1);
         
-        Assert.assertFalse(state.isSimple());
+        Assertions.assertFalse(state.isSimple());
     }
         
     @Test
     public void testIsCompositeFalse() {
         State state = new State();
-        Assert.assertFalse(state.isComposite());
+        Assertions.assertFalse(state.isComposite());
     }
         
     @Test
@@ -131,7 +131,7 @@ public class StateTest {
         State state = new State();
         state.addChild(child);
         
-        Assert.assertTrue(state.isComposite());
+        Assertions.assertTrue(state.isComposite());
     }
         
     @Test
@@ -141,7 +141,7 @@ public class StateTest {
         State state = new State();
         state.addChild(state1);
         
-        Assert.assertTrue(state.isComposite());
+        Assertions.assertTrue(state.isComposite());
     }
         
     @Test
@@ -149,7 +149,7 @@ public class StateTest {
         State state = new State();
         state.setParent(new Parallel());
         
-        Assert.assertTrue(state.isRegion());
+        Assertions.assertTrue(state.isRegion());
     }
         
     @Test
@@ -157,13 +157,13 @@ public class StateTest {
         State state = new State();
         state.setParent(new State());
         
-        Assert.assertFalse(state.isRegion());
+        Assertions.assertFalse(state.isRegion());
     }
     
     @Test
     public void testInitialAttribute() throws Exception {
         SCXMLExecutor exec = SCXMLTestHelper.getExecutor("org/apache/commons/scxml2/model/state-01.xml");
         exec.go();
-        Assert.assertEquals("s11", exec.getStatus().getStates().iterator().next().getId());
+        Assertions.assertEquals("s11", exec.getStatus().getStates().iterator().next().getId());
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/model/StatelessModelTest.java
+++ b/src/test/java/org/apache/commons/scxml2/model/StatelessModelTest.java
@@ -23,8 +23,8 @@ import org.apache.commons.scxml2.SCXMLExecutor;
 import org.apache.commons.scxml2.SCXMLTestHelper;
 import org.apache.commons.scxml2.TriggerEvent;
 import org.apache.commons.scxml2.EventBuilder;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 /**
  * Unit tests {@link org.apache.commons.scxml2.SCXMLExecutor}.
  */
@@ -41,7 +41,7 @@ public class StatelessModelTest {
         exec01.go();
         SCXMLExecutor exec02 = SCXMLTestHelper.getExecutor(scxml);
         exec02.go();
-        Assert.assertFalse(exec01 == exec02);
+        Assertions.assertFalse(exec01 == exec02);
         runSimultaneousTest(exec01, exec02);
     }
 
@@ -69,7 +69,7 @@ public class StatelessModelTest {
         exec01.go();
         SCXMLExecutor exec02 = SCXMLTestHelper.getExecutor(scxml01par);
         exec02.go();
-        Assert.assertFalse(exec01 == exec02);
+        Assertions.assertFalse(exec01 == exec02);
 
         Set<EnterableState> currentStates = exec01.getStatus().getStates();
         checkParallelStates(currentStates, "state1.init", "state2.init", "exec01");
@@ -99,7 +99,7 @@ public class StatelessModelTest {
         SCXML scxml02par = SCXMLTestHelper.parse("org/apache/commons/scxml2/model/stateless-parallel-01.xml");
         SCXMLExecutor exec01 = SCXMLTestHelper.getExecutor(scxml01par);
         exec01.go();
-        Assert.assertTrue(scxml01par != scxml02par);
+        Assertions.assertTrue(scxml01par != scxml02par);
 
         Set<EnterableState> currentStates = exec01.getStatus().getStates();
         checkParallelStates(currentStates, "state1.init", "state2.init", "exec01");
@@ -116,22 +116,22 @@ public class StatelessModelTest {
     private void checkParallelStates(Set<EnterableState> currentStates,
             String s1, String s2, String label) {
         Iterator<EnterableState> i = currentStates.iterator();
-        Assert.assertTrue("Not enough states", i.hasNext());
+        Assertions.assertTrue(i.hasNext(), "Not enough states");
         String cs1 = i.next().getId();
         String cs2;
         if (s2 != null) {
-            Assert.assertTrue("Not enough states, found one state: " + cs1, i.hasNext());
+            Assertions.assertTrue(i.hasNext(), "Not enough states, found one state: " + cs1);
             cs2 = i.next().getId();
-            Assert.assertFalse("Too many states", i.hasNext());
+            Assertions.assertFalse(i.hasNext(), "Too many states");
             if (s2.equals(cs2)) {
                 cs2 = null;
             } else if (s1.equals(cs2)) {
                 cs2 = null;
             } else {
-                Assert.fail(label + " in unexpected state " + cs2);
+                Assertions.fail(label + " in unexpected state " + cs2);
             }
         } else {
-            Assert.assertFalse("Too many states", i.hasNext());
+            Assertions.assertFalse(i.hasNext(), "Too many states");
         }
         if (s1 != null && s1.equals(cs1)) {
             return;
@@ -139,47 +139,47 @@ public class StatelessModelTest {
         if (s2 != null && s2.equals(cs1)) {
             return;
         }
-        Assert.fail(label + " in unexpected state " + cs1);
+        Assertions.fail(label + " in unexpected state " + cs1);
     }
 
     private void runSimultaneousTest(SCXMLExecutor exec01, SCXMLExecutor exec02) throws Exception {
         //// Interleaved
         // exec01
         Set<EnterableState> currentStates = exec01.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("ten", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("ten", currentStates.iterator().next().getId());
         currentStates = fireEvent("done.state.ten", exec01);
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("twenty", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("twenty", currentStates.iterator().next().getId());
         // exec02
         currentStates = exec02.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("ten", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("ten", currentStates.iterator().next().getId());
         // exec01
         currentStates = fireEvent("done.state.twenty", exec01);
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("thirty", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("thirty", currentStates.iterator().next().getId());
         // exec02
         currentStates = fireEvent("done.state.ten", exec02);
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("twenty", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("twenty", currentStates.iterator().next().getId());
         currentStates = fireEvent("done.state.twenty", exec02);
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("thirty", currentStates.iterator().next().getId());
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("thirty", currentStates.iterator().next().getId());
     }
 
     private void runSequentialTest(SCXMLExecutor exec) throws Exception {
         Set<EnterableState> currentStates = exec.getStatus().getStates();
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("ten", (currentStates.iterator().
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("ten", (currentStates.iterator().
             next()).getId());
         currentStates = fireEvent("done.state.ten", exec);
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("twenty", (currentStates.iterator().
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("twenty", (currentStates.iterator().
             next()).getId());
         currentStates = fireEvent("done.state.twenty", exec);
-        Assert.assertEquals(1, currentStates.size());
-        Assert.assertEquals("thirty", (currentStates.iterator().
+        Assertions.assertEquals(1, currentStates.size());
+        Assertions.assertEquals("thirty", (currentStates.iterator().
             next()).getId());
     }
 

--- a/src/test/java/org/apache/commons/scxml2/model/TransitionTargetTest.java
+++ b/src/test/java/org/apache/commons/scxml2/model/TransitionTargetTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.commons.scxml2.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TransitionTargetTest {
 
@@ -26,7 +26,7 @@ public class TransitionTargetTest {
         State state = new State();
         State context = new State();
 
-        Assert.assertFalse(state.isDescendantOf(context));
+        Assertions.assertFalse(state.isDescendantOf(context));
     }
 
     @Test
@@ -35,7 +35,7 @@ public class TransitionTargetTest {
         state.setParent(new State());
         State context = new State();
 
-        Assert.assertFalse(state.isDescendantOf(context));
+        Assertions.assertFalse(state.isDescendantOf(context));
     }
 
     @Test
@@ -44,7 +44,7 @@ public class TransitionTargetTest {
         State context = new State();
         state.setParent(context);
 
-        Assert.assertTrue(state.isDescendantOf(context));
+        Assertions.assertTrue(state.isDescendantOf(context));
     }
 
     @Test
@@ -56,6 +56,6 @@ public class TransitionTargetTest {
         parent.setParent(context);
         state.setParent(parent);
 
-        Assert.assertTrue(state.isDescendantOf(context));
+        Assertions.assertTrue(state.isDescendantOf(context));
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/model/TransitionTest.java
+++ b/src/test/java/org/apache/commons/scxml2/model/TransitionTest.java
@@ -16,29 +16,29 @@
  */
 package org.apache.commons.scxml2.model;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TransitionTest {
 
     private Transition transition;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         transition = new Transition();
     }
         
     @Test
     public void testGetTargets() {
-        Assert.assertEquals(0, transition.getTargets().size());
+        Assertions.assertEquals(0, transition.getTargets().size());
 
         State state = new State();
         state.setId("1");
 
         transition.getTargets().add(state);
 
-        Assert.assertEquals(1, transition.getTargets().size());
-        Assert.assertEquals("1", transition.getTargets().iterator().next().getId());
+        Assertions.assertEquals(1, transition.getTargets().size());
+        Assertions.assertEquals("1", transition.getTargets().iterator().next().getId());
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/semantics/SCXMLSemanticsImplTest.java
+++ b/src/test/java/org/apache/commons/scxml2/semantics/SCXMLSemanticsImplTest.java
@@ -24,8 +24,8 @@ import org.apache.commons.scxml2.env.SimpleErrorReporter;
 import org.apache.commons.scxml2.model.EnterableState;
 import org.apache.commons.scxml2.model.Parallel;
 import org.apache.commons.scxml2.model.State;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SCXMLSemanticsImplTest {
 
@@ -33,7 +33,7 @@ public class SCXMLSemanticsImplTest {
     public void testIsLegalConfigNoStates() {
         Set<EnterableState> states = new HashSet<>();
 
-        Assert.assertTrue(new SCXMLSemanticsImpl().isLegalConfiguration(states, new SimpleErrorReporter()));
+        Assertions.assertTrue(new SCXMLSemanticsImpl().isLegalConfiguration(states, new SimpleErrorReporter()));
     }
 
     @Test
@@ -58,9 +58,9 @@ public class SCXMLSemanticsImplTest {
 
         MockErrorReporter errorReporter = new MockErrorReporter();
 
-        Assert.assertFalse(new SCXMLSemanticsImpl().isLegalConfiguration(states, errorReporter));
-        Assert.assertEquals(ErrorConstants.ILLEGAL_CONFIG, errorReporter.getErrCode());
-        Assert.assertEquals("Not all AND states active for parallel 4", errorReporter.getErrDetail());
+        Assertions.assertFalse(new SCXMLSemanticsImpl().isLegalConfiguration(states, errorReporter));
+        Assertions.assertEquals(ErrorConstants.ILLEGAL_CONFIG, errorReporter.getErrCode());
+        Assertions.assertEquals("Not all AND states active for parallel 4", errorReporter.getErrDetail());
     }
 
     @Test
@@ -77,9 +77,9 @@ public class SCXMLSemanticsImplTest {
 
         MockErrorReporter errorReporter = new MockErrorReporter();
 
-        Assert.assertFalse(new SCXMLSemanticsImpl().isLegalConfiguration(states, errorReporter));
-        Assert.assertEquals(ErrorConstants.ILLEGAL_CONFIG, errorReporter.getErrCode());
-        Assert.assertEquals("Multiple top-level OR states active!", errorReporter.getErrDetail());
+        Assertions.assertFalse(new SCXMLSemanticsImpl().isLegalConfiguration(states, errorReporter));
+        Assertions.assertEquals(ErrorConstants.ILLEGAL_CONFIG, errorReporter.getErrCode());
+        Assertions.assertEquals("Multiple top-level OR states active!", errorReporter.getErrDetail());
     }
 
     @Test
@@ -103,8 +103,8 @@ public class SCXMLSemanticsImplTest {
 
         MockErrorReporter errorReporter = new MockErrorReporter();
 
-        Assert.assertFalse(new SCXMLSemanticsImpl().isLegalConfiguration(states, errorReporter));
-        Assert.assertEquals(ErrorConstants.ILLEGAL_CONFIG, errorReporter.getErrCode());
-        Assert.assertEquals("Multiple OR states active for state parentid", errorReporter.getErrDetail());
+        Assertions.assertFalse(new SCXMLSemanticsImpl().isLegalConfiguration(states, errorReporter));
+        Assertions.assertEquals(ErrorConstants.ILLEGAL_CONFIG, errorReporter.getErrCode());
+        Assertions.assertEquals("Multiple OR states active for state parentid", errorReporter.getErrDetail());
     }
 }


### PR DESCRIPTION
This PR migrates the project to the modern JUnit Jupiter 5.3.1 testing framework.
Since JUnit Jupiter is not backwards compatible to JUnit 4.x, or even JUnit Vintage 5.x, the patch is a tad large, although most of the changes are just cosmetic.

1. Maven changes:
     1. `org.junit.jupiter:junit-jupiter-api` was added to provide the new APIs used.
     1. `org.junit.jupiter:junit-jupiter-engine` was added as a testing engine. Its presence allows `maven-surefire-plugin` to use the Jupiter provider in order to execute tests.
     1. `junit:junit` was removed, as it's no longer in use.
     1. The parent module, `org.apache.commons:commons-parent` was upgraded to the latest version, `47`, in order to consume `org.apache.maven.plugins:maven-surefire-plugin:2.22.0` that natively supports Jupiter tests.

1. Annotations:
     1. `org.junit.jupiter.api.Test` was used as a drop in replacement for `org.juit.Test` without arguments. See 3.b for handling of the `@Test` annotation with an `expected` argument.
     1. `org.junit.jupiter.api.BeforeEach` was used as an drop in replacement for `org.junit.Before`.
     1. `org.junit.jupiter.api.AfterEach` was used as a drop in replacement for `org.junit.After`.
     1. `org.junit.jupiter.api.BeforeAll` was used as a drop in replacement for `org.junit.BeforeClass`.
     1. `org.junit.jupiter.api.AfterAll` was used as a drop in replacement for `org.junit.AfterClass`.

3. Assertions:
     1. `org.junit.jupiter.api.Assertions`' methods were used as a drop in replacements for `org.junit.Assert`'s methods with the same name in the simple case of an assertion without a message. In the case of an assertion with a message, `org.junit.jupiter.api.Assertions`' methods were used, but the argument order was changed - `Assert`'s methods take the message as the first argument, while `Assertions`' methods take the message as the last argument.
    1. `org.junit.jupiter.api.Assertions#assertThrows` was used to assert a specific exception was thrown instead of an `org.junit.Test` annotation with an `expected` argument. This technique has a side bonus of making the tests slightly stricter, as now they assert the exception was thrown from a specific line and prevent false posivites where the test's "set-up" code accidentally threw that exception. The `throws` clauses of these methods were cleaned up from exceptions that can no longer be thrown in order to avoid compilation warnings.

4. Miscelanious
    1. The redundant `main` methods in the test classes of the `org.apache.commons.scxml2.env.javascript` package were removed, and the Javadoc was updated accordingly.