### PR TITLE
SCXML-284 Clean up exception handling in tests

### DIFF
--- a/src/test/java/org/apache/commons/scxml2/env/SimpleContextTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/SimpleContextTest.java
@@ -189,13 +189,11 @@ public class SimpleContextTest {
         rootContext.set("key", "root");
         SimpleContext rootEffectiveContext = new SimpleContext(rootContext, new EffectiveContextMap(rootContext));
         SimpleContext parentContext = new SimpleContext(rootEffectiveContext);
-        try {
-            new EffectiveContextMap(parentContext);
-            Assertions.fail("Nested EffectiveContextMap wrapping should fail");
-        }
-        catch (IllegalArgumentException e) {
-            // good
-        }
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new EffectiveContextMap(parentContext),
+                "Nested EffectiveContextMap wrapping should fail"
+        );
     }
 
     @Test

--- a/src/test/java/org/apache/commons/scxml2/env/SimpleContextTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/SimpleContextTest.java
@@ -28,7 +28,7 @@ public class SimpleContextTest {
     private SimpleContext context;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         context = new SimpleContext();
     }
     

--- a/src/test/java/org/apache/commons/scxml2/env/groovy/GroovyEvaluatorTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/groovy/GroovyEvaluatorTest.java
@@ -81,13 +81,12 @@ public class GroovyEvaluatorTest {
     public void testErrorMessage() {
         Evaluator eval = new GroovyEvaluator();
         Assertions.assertNotNull(eval);
-        try {
-            eval.eval(ctx, BAD_EXPRESSION);
-            Assertions.fail("GroovyEvaluator should throw SCXMLExpressionException");
-        } catch (SCXMLExpressionException e) {
-            Assertions.assertTrue(e.getMessage().startsWith("eval('" + BAD_EXPRESSION + "'):"),
-                    "GroovyEvaluator: Incorrect error message");
-        }
+        SCXMLExpressionException e = Assertions.assertThrows(
+                SCXMLExpressionException.class,
+                () -> eval.eval(ctx, BAD_EXPRESSION),
+                "GroovyEvaluator should throw SCXMLExpressionException");
+        Assertions.assertTrue(e.getMessage().startsWith("eval('" + BAD_EXPRESSION + "'):"),
+                "GroovyEvaluator: Incorrect error message");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/scxml2/env/javascript/JSEvaluatorTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/javascript/JSEvaluatorTest.java
@@ -151,15 +151,12 @@ public class JSEvaluatorTest {
         Evaluator evaluator = new JSEvaluator();
 
         Assertions.assertNotNull(evaluator);
-
-        try {
-            evaluator.eval(context,BAD_EXPRESSION);
-            Assertions.fail          ("JSEvaluator should throw SCXMLExpressionException");
-
-        } catch (SCXMLExpressionException x) {
-            Assertions.assertTrue(x.getMessage().startsWith("eval('" + BAD_EXPRESSION + "')"),
-                    "JSEvaluator: Incorrect error message");
-        }
+        SCXMLExpressionException x= Assertions.assertThrows(
+                SCXMLExpressionException.class,
+                () ->  evaluator.eval(context,BAD_EXPRESSION),
+                "JSEvaluator should throw SCXMLExpressionException");
+        Assertions.assertTrue(x.getMessage().startsWith("eval('" + BAD_EXPRESSION + "')"),
+                "JSEvaluator: Incorrect error message");
     }
 
     /**
@@ -206,14 +203,11 @@ public class JSEvaluatorTest {
     @Test
     public void testInvalidVarExpressions() {
         for (TestItem item: VAR_EXPRESSIONS) {
-            try {
-                Assertions.assertNull    (context.get("fibonacci"));
-                evaluator.eval(context,item.expression);
-                Assertions.fail          ("Evaluated invalid <var... expression: " + item.expression);
-
-            } catch (SCXMLExpressionException x) {
-                // expected, ignore
-            }
+            Assertions.assertNull(context.get("fibonacci"));
+            Assertions.assertThrows(
+                    SCXMLExpressionException.class,
+                    () -> evaluator.eval(context,item.expression),
+                    "Evaluated invalid <var... expression: " + item.expression);
         }
     }
 
@@ -235,14 +229,10 @@ public class JSEvaluatorTest {
     @Test
     public void testInvalidDataModelExpressions() {
         Assertions.assertNull(context.get("forestx"));
-
-        try {
-            evaluator.eval(context,"forestx.tree.branch.twig");
-            Assertions.fail          ("Evaluated invalid DataModel expression: " + "forestx.tree.branch.twig");
-
-        } catch (SCXMLExpressionException x) {
-            // expected, ignore
-        }
+        Assertions.assertThrows(
+                SCXMLExpressionException.class,
+                () -> evaluator.eval(context,"forestx.tree.branch.twig"),
+                "Evaluated invalid DataModel expression: " + "forestx.tree.branch.twig");
     }
 
     /**

--- a/src/test/java/org/apache/commons/scxml2/env/javascript/JSExampleTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/javascript/JSExampleTest.java
@@ -61,7 +61,7 @@ public class JSExampleTest {
     
     public static class EventDataMapTest extends Action {
         @Override
-        public void execute(ActionExecutionContext exctx) throws ModelException, SCXMLExpressionException {
+        public void execute(ActionExecutionContext exctx) {
             exctx.getInternalIOProcessor()
                     .addEvent(new EventBuilder("ok",TriggerEvent.SIGNAL_EVENT).data("and its ok with me to").build());
         }

--- a/src/test/java/org/apache/commons/scxml2/env/javascript/JavaScriptEngineTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/javascript/JavaScriptEngineTest.java
@@ -38,7 +38,7 @@ public class JavaScriptEngineTest {
     private JSContext context;
 
     @BeforeEach
-    public void before() throws Exception {
+    public void before() {
         evaluator = new JSEvaluator();
         _systemContext = new JSContext();
         SCXMLSystemContext systemContext = new SCXMLSystemContext(_systemContext);

--- a/src/test/java/org/apache/commons/scxml2/env/jexl/JexlEvaluatorTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/jexl/JexlEvaluatorTest.java
@@ -52,13 +52,12 @@ public class JexlEvaluatorTest {
     public void testErrorMessage() {
         Evaluator eval = new JexlEvaluator();
         Assertions.assertNotNull(eval);
-        try {
-            eval.eval(ctx, BAD_EXPRESSION);
-            Assertions.fail("JexlEvaluator should throw SCXMLExpressionException");
-        } catch (SCXMLExpressionException e) {
-            Assertions.assertTrue(e.getMessage().startsWith("eval('" + BAD_EXPRESSION + "'):"),
-                    "JexlEvaluator: Incorrect error message");
-        }
+        SCXMLExpressionException e = Assertions.assertThrows(
+                SCXMLExpressionException.class,
+                () -> eval.eval(ctx, BAD_EXPRESSION),
+                "JexlEvaluator should throw SCXMLExpressionException");
+        Assertions.assertTrue(e.getMessage().startsWith("eval('" + BAD_EXPRESSION + "'):"),
+                "JexlEvaluator: Incorrect error message");
     }
 
 }

--- a/src/test/java/org/apache/commons/scxml2/invoke/InvokeParamNameTest.java
+++ b/src/test/java/org/apache/commons/scxml2/invoke/InvokeParamNameTest.java
@@ -81,15 +81,13 @@ public class InvokeParamNameTest {
         private String invokeId;
 
         @Override
-        public void invoke(String url, Map<String, Object> params)
-        throws InvokerException {
+        public void invoke(String url, Map<String, Object> params) {
             lastURL = url;
             lastParams = params;
         }
 
         @Override
-        public void invokeContent(String content, Map<String, Object> params)
-                throws InvokerException {
+        public void invokeContent(String content, Map<String, Object> params) {
             lastURL = null;
             lastParams = params;
         }
@@ -103,12 +101,12 @@ public class InvokeParamNameTest {
         }
 
         @Override
-        public void cancel() throws InvokerException {
+        public void cancel() {
             // Not needed
         }
 
         @Override
-        public void parentEvent(TriggerEvent evt) throws InvokerException {
+        public void parentEvent(TriggerEvent evt) {
             // Not needed
         }
 

--- a/src/test/java/org/apache/commons/scxml2/io/ContentParserTest.java
+++ b/src/test/java/org/apache/commons/scxml2/io/ContentParserTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class ContentParserTest {
 
     @Test
-    public void testTrimContent() throws Exception {
+    public void testTrimContent() {
         Assertions.assertEquals(null, ContentParser.trimContent(null));
         Assertions.assertEquals("", ContentParser.trimContent(""));
         Assertions.assertEquals("", ContentParser.trimContent(" "));
@@ -42,7 +42,7 @@ public class ContentParserTest {
     }
 
     @Test
-    public void testSpaceNormalizeContent() throws Exception {
+    public void testSpaceNormalizeContent() {
         Assertions.assertEquals(null, ContentParser.spaceNormalizeContent(null));
         Assertions.assertEquals("", ContentParser.spaceNormalizeContent(""));
         Assertions.assertEquals("a", ContentParser.spaceNormalizeContent("a"));

--- a/src/test/java/org/apache/commons/scxml2/io/SCXMLReaderTest.java
+++ b/src/test/java/org/apache/commons/scxml2/io/SCXMLReaderTest.java
@@ -353,7 +353,7 @@ public class SCXMLReaderTest {
         private ParsedValue parsedValue;
 
         @Override
-        public void execute(ActionExecutionContext exctx) throws ModelException, SCXMLExpressionException {
+        public void execute(ActionExecutionContext exctx) {
             // Not relevant to test
         }
 

--- a/src/test/java/org/apache/commons/scxml2/io/SCXMLReaderTest.java
+++ b/src/test/java/org/apache/commons/scxml2/io/SCXMLReaderTest.java
@@ -209,11 +209,11 @@ public class SCXMLReaderTest {
         // In the lenient/silent mode (strict == false && silent == true),
         // no model exception is logged.
         clearRecordedLogMessages();
-        configuration = new Configuration();
-        configuration.setStrict(false);
-        configuration.setSilent(true);
+        Configuration configuration2 = new Configuration();
+        configuration2.setStrict(false);
+        configuration2.setSilent(true);
         SCXMLReader.read(SCXMLTestHelper.getResource("org/apache/commons/scxml2/io/scxml-with-invalid-elems.xml"),
-                configuration);
+                configuration2);
         Assertions.assertNotNull(scxml);
         Assertions.assertNotNull(serialize(scxml));
         foo = (Final) scxml.getInitialTransition().getTargets().iterator().next();
@@ -231,16 +231,15 @@ public class SCXMLReaderTest {
         // In strict/verbose mode (strict == true && silent == false), it should fail to read the model and catch a model exception
         // with warning logs because of the invalid <baddata> element.
         clearRecordedLogMessages();
-        configuration = new Configuration();
-        configuration.setStrict(true);
-        configuration.setSilent(false);
-        try {
-            SCXMLReader.read(SCXMLTestHelper.getResource("org/apache/commons/scxml2/io/scxml-with-invalid-elems.xml"),
-                    configuration);
-            Assertions.fail("In strict mode, it should have thrown a model exception.");
-        } catch (ModelException e) {
-            Assertions.assertTrue(e.getMessage().contains("Ignoring unknown or invalid element <baddata>"));
-        }
+        Configuration configuration3 = new Configuration();
+        configuration3.setStrict(true);
+        configuration3.setSilent(false);
+        ModelException e = Assertions.assertThrows(
+                ModelException.class,
+                () ->  SCXMLReader.read(SCXMLTestHelper.getResource("org/apache/commons/scxml2/io/scxml-with-invalid-elems.xml"),
+                    configuration3),
+                "In strict mode, it should have thrown a model exception.");
+        Assertions.assertTrue(e.getMessage().contains("Ignoring unknown or invalid element <baddata>"));
 
         assertContainsRecordedLogMessage("Ignoring unknown or invalid element <baddata> in namespace \"http://www.w3.org/2005/07/scxml\" as child of <datamodel>");
         assertNotContainsRecordedLogMessage("Ignoring unknown or invalid element <baddata> in namespace \"http://www.example.com/scxml\" as child of <datamodel>");
@@ -250,17 +249,15 @@ public class SCXMLReaderTest {
         // In strict/silent mode (strict == true && silent == true), it should fail to read the model and catch a model exception
         // without warning logs because of the invalid <baddata> element.
         clearRecordedLogMessages();
-        scxml = null;
-        configuration = new Configuration();
-        configuration.setStrict(true);
-        configuration.setSilent(true);
-        try {
-            scxml = SCXMLReader.read(SCXMLTestHelper.getResource("org/apache/commons/scxml2/io/scxml-with-invalid-elems.xml"),
-                    configuration);
-            Assertions.fail("In strict mode, it should have thrown a model exception.");
-        } catch (ModelException e) {
-            Assertions.assertTrue(e.getMessage().contains("Ignoring unknown or invalid element <baddata>"));
-        }
+        Configuration configuration4 = new Configuration();
+        configuration4.setStrict(true);
+        configuration4.setSilent(true);
+        e = Assertions.assertThrows(
+                ModelException.class,
+                () ->  SCXMLReader.read(SCXMLTestHelper.getResource("org/apache/commons/scxml2/io/scxml-with-invalid-elems.xml"),
+                    configuration4),
+                "In strict mode, it should have thrown a model exception.");
+        Assertions.assertTrue(e.getMessage().contains("Ignoring unknown or invalid element <baddata>"));
         assertNotContainsRecordedLogMessage("Ignoring unknown or invalid element <baddata> in namespace \"http://www.w3.org/2005/07/scxml\" as child of <datamodel>");
         assertNotContainsRecordedLogMessage("Ignoring unknown or invalid element <baddata> in namespace \"http://www.example.com/scxml\" as child of <datamodel>");
         assertNotContainsRecordedLogMessage("Ignoring unknown or invalid element <trace> in namespace \"http://www.w3.org/2005/07/scxml\" as child of <onentry>");

--- a/src/test/java/org/apache/commons/scxml2/io/SCXMLRequiredAttributesTest.java
+++ b/src/test/java/org/apache/commons/scxml2/io/SCXMLRequiredAttributesTest.java
@@ -25,8 +25,8 @@ import org.apache.commons.scxml2.model.SCXML;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test enforcement of required SCXML element attributes, spec https://www.w3.org/TR/2015/REC-scxml-20150901
@@ -154,80 +154,66 @@ public class SCXMLRequiredAttributesTest {
     }
 
     @Test
-    public void testSCXMLMissingVersion() throws Exception {
-        try {
-            SCXMLTestHelper.parse(new StringReader(SCXML_WITH_MISSING_VERSION), null);
-            fail("SCXML reading should have failed due to missing version in SCXML");
-        }
-        catch (ModelException e) {
-            assertTrue(e.getMessage().startsWith("<scxml> is missing required attribute \"version\" value"));
-        }
+    public void testSCXMLMissingVersion() {
+        ModelException e = assertThrows(
+                ModelException.class,
+                () -> SCXMLTestHelper.parse(new StringReader(SCXML_WITH_MISSING_VERSION), null),
+                "SCXML reading should have failed due to missing version in SCXML");
+        assertTrue(e.getMessage().startsWith("<scxml> is missing required attribute \"version\" value"));
     }
 
     @Test
-    public void testSCXMLInvalidVersion() throws Exception {
-        try {
-            SCXMLTestHelper.parse(new StringReader(SCXML_WITH_INVALID_VERSION), null);
-            fail("SCXML reading should have failed due to missing version in SCXML");
-        }
-        catch (ModelException e) {
-            assertEquals("The <scxml> element defines an unsupported version \"2.0\", only version \"1.0\" is supported.", e.getMessage());
-        }
+    public void testSCXMLInvalidVersion() {
+        ModelException e = assertThrows(
+                ModelException.class,
+                () -> SCXMLTestHelper.parse(new StringReader(SCXML_WITH_INVALID_VERSION), null),
+                "SCXML reading should have failed due to missing version in SCXML");
+        assertEquals("The <scxml> element defines an unsupported version \"2.0\", only version \"1.0\" is supported.", e.getMessage());
     }
 
     @Test
-    public void testSCXMLMissingIfCond() throws Exception {
-        try {
-            SCXMLTestHelper.parse(new StringReader(SCXML_WITH_MISSING_IF_COND), null);
-            fail("SCXML reading should have failed due to missing if condition in SCXML");
-        }
-        catch (ModelException e) {
-            assertTrue(e.getMessage().startsWith("<if> is missing required attribute \"cond\" value"));
-        }
+    public void testSCXMLMissingIfCond() {
+        ModelException e = assertThrows(
+                ModelException.class,
+                () -> SCXMLTestHelper.parse(new StringReader(SCXML_WITH_MISSING_IF_COND), null),
+                "SCXML reading should have failed due to missing if condition in SCXML");
+        assertTrue(e.getMessage().startsWith("<if> is missing required attribute \"cond\" value"));
     }
 
     @Test
-    public void testSCXMLMissingElseIfCond() throws Exception {
-        try {
-            SCXMLTestHelper.parse(new StringReader(SCXML_WITH_MISSING_ELSEIF_COND), null);
-            fail("SCXML reading should have failed due to missing elseif condition in SCXML");
-        }
-        catch (ModelException e) {
-            assertTrue(e.getMessage().startsWith("<elseif> is missing required attribute \"cond\" value"));
-        }
+    public void testSCXMLMissingElseIfCond() {
+        ModelException e = assertThrows(
+                ModelException.class,
+                () -> SCXMLTestHelper.parse(new StringReader(SCXML_WITH_MISSING_ELSEIF_COND), null),
+                "SCXML reading should have failed due to missing elseif condition in SCXML");
+        assertTrue(e.getMessage().startsWith("<elseif> is missing required attribute \"cond\" value"));
     }
 
     @Test
-    public void testSCXMLMissingDataId() throws Exception {
-        try {
-            SCXMLTestHelper.parse(new StringReader(SCXML_WITH_MISSING_DATA_ID), null);
-            fail("SCXML reading should have failed due to missing data id in SCXML");
-        }
-        catch (ModelException e) {
-            assertTrue(e.getMessage().startsWith("<data> is missing required attribute \"id\" value"));
-        }
+    public void testSCXMLMissingDataId() {
+        ModelException e = assertThrows(
+                ModelException.class,
+                () -> SCXMLTestHelper.parse(new StringReader(SCXML_WITH_MISSING_DATA_ID), null),
+                "SCXML reading should have failed due to missing data id in SCXML");
+        assertTrue(e.getMessage().startsWith("<data> is missing required attribute \"id\" value"));
     }
 
     @Test
-    public void testSCXMLMissingAssignLocation() throws Exception {
-        try {
-            SCXMLTestHelper.parse(new StringReader(SCXML_WITH_MISSING_ASSIGN_LOCATION), null);
-            fail("SCXML reading should have failed due to missing assign location in SCXML");
-        }
-        catch (ModelException e) {
-            assertTrue(e.getMessage().startsWith("<assign> is missing required attribute \"location\" value"));
-        }
+    public void testSCXMLMissingAssignLocation() {
+        ModelException e = assertThrows(
+                ModelException.class,
+                () -> SCXMLTestHelper.parse(new StringReader(SCXML_WITH_MISSING_ASSIGN_LOCATION), null),
+                "SCXML reading should have failed due to missing assign location in SCXML");
+        assertTrue(e.getMessage().startsWith("<assign> is missing required attribute \"location\" value"));
     }
 
     @Test
-    public void testSCXMLMissingParamName() throws Exception {
-        try {
-            SCXMLTestHelper.parse(new StringReader(SCXML_WITH_MISSING_PARAM_NAME), null);
-            fail("SCXML reading should have failed due to missing param name in SCXML");
-        }
-        catch (ModelException e) {
-            assertTrue(e.getMessage().startsWith("<param> is missing required attribute \"name\" value"));
-        }
+    public void testSCXMLMissingParamName() {
+        ModelException e = assertThrows(
+                ModelException.class,
+                () -> SCXMLTestHelper.parse(new StringReader(SCXML_WITH_MISSING_PARAM_NAME), null),
+                "SCXML reading should have failed due to missing param name in SCXML");
+        assertTrue(e.getMessage().startsWith("<param> is missing required attribute \"name\" value"));
     }
 
     @Test
@@ -237,25 +223,21 @@ public class SCXMLRequiredAttributesTest {
     }
 
     @Test
-    public void testSCXMLMissingForeachArray() throws Exception {
-        try {
-            SCXMLTestHelper.parse(new StringReader(SCXML_WITH_MISSING_FOREACH_ARRAY), null);
-            fail("SCXML reading should have failed due to missing foreach array in SCXML");
-        }
-        catch (ModelException e) {
-            assertTrue(e.getMessage().startsWith("<foreach> is missing required attribute \"array\" value"));
-        }
+    public void testSCXMLMissingForeachArray() {
+        ModelException e = assertThrows(
+                ModelException.class,
+                () -> SCXMLTestHelper.parse(new StringReader(SCXML_WITH_MISSING_FOREACH_ARRAY), null),
+                "SCXML reading should have failed due to missing foreach array in SCXML");
+        assertTrue(e.getMessage().startsWith("<foreach> is missing required attribute \"array\" value"));
     }
 
     @Test
-    public void testSCXMLMissingForeachItem() throws Exception {
-        try {
-            SCXMLTestHelper.parse(new StringReader(SCXML_WITH_MISSING_FOREACH_ITEM), null);
-            fail("SCXML reading should have failed due to missing foreach item in SCXML");
-        }
-        catch (ModelException e) {
-            assertTrue(e.getMessage().startsWith("<foreach> is missing required attribute \"item\" value"));
-        }
+    public void testSCXMLMissingForeachItem() {
+        ModelException e = assertThrows(
+                ModelException.class,
+                () -> SCXMLTestHelper.parse(new StringReader(SCXML_WITH_MISSING_FOREACH_ITEM), null),
+                "SCXML reading should have failed due to missing foreach item in SCXML");
+        assertTrue(e.getMessage().startsWith("<foreach> is missing required attribute \"item\" value"));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/scxml2/io/SCXMLWriterTest.java
+++ b/src/test/java/org/apache/commons/scxml2/io/SCXMLWriterTest.java
@@ -123,7 +123,7 @@ public class SCXMLWriterTest {
      }
 
     @Test
-    public void testSerializeGlobalScript() throws IOException, ModelException, XMLStreamException {
+    public void testSerializeGlobalScript() throws IOException, XMLStreamException {
         SCXML scxml = new CommonsSCXML();
         scxml.setVersion("1.0");
         scxml.setInitial("S1");

--- a/src/test/java/org/apache/commons/scxml2/io/StateSrcTest.java
+++ b/src/test/java/org/apache/commons/scxml2/io/StateSrcTest.java
@@ -43,25 +43,23 @@ public class StateSrcTest {
     }
     
     @Test
-    public void testBadSrcInclude() throws Exception {
-        try {
-            SCXMLReader.read(SCXMLTestHelper.getResource("org/apache/commons/scxml2/io/src-test-4.xml"));
-            Assertions.fail("Document with bad <state> src attribute shouldn't be parsed!");
-        } catch (ModelException me) {
-            Assertions.assertTrue(me.getMessage() != null && me.getMessage().contains("Source attribute in <state src="),
-                    "Unexpected error message for bad <state> 'src' URI");
-        }
+    public void testBadSrcInclude() {
+        ModelException me = Assertions.assertThrows(
+                ModelException.class,
+                () -> SCXMLReader.read(SCXMLTestHelper.getResource("org/apache/commons/scxml2/io/src-test-4.xml")),
+                "Document with bad <state> src attribute shouldn't be parsed!");
+        Assertions.assertTrue(me.getMessage() != null && me.getMessage().contains("Source attribute in <state src="),
+                "Unexpected error message for bad <state> 'src' URI");
     }
     
     @Test
-    public void testBadSrcFragmentInclude() throws Exception {
-        try {
-            SCXMLReader.read(SCXMLTestHelper.getResource("org/apache/commons/scxml2/io/src-test-5.xml"));
-            Assertions.fail("Document with bad <state> src attribute shouldn't be parsed!");
-        } catch (ModelException me) {
-            Assertions.assertTrue(me.getMessage() != null && me.getMessage().contains("URI Fragment in <state src="),
-                    "Unexpected error message for bad <state> 'src' URI fragment");
-        }
+    public void testBadSrcFragmentInclude() {
+        ModelException me = Assertions.assertThrows(
+                ModelException.class,
+                () -> SCXMLReader.read(SCXMLTestHelper.getResource("org/apache/commons/scxml2/io/src-test-5.xml")),
+                "Document with bad <state> src attribute shouldn't be parsed!");
+        Assertions.assertTrue(me.getMessage() != null && me.getMessage().contains("URI Fragment in <state src="),
+                "Unexpected error message for bad <state> 'src' URI fragment");
     }
 }
 

--- a/src/test/java/org/apache/commons/scxml2/issues/Issue112Test.java
+++ b/src/test/java/org/apache/commons/scxml2/issues/Issue112Test.java
@@ -69,11 +69,7 @@ public class Issue112Test {
         // Rest of the events in this test are added by custom action invocation during processing of the one above.
         // Same concept applies to adding events in listeners, invokes and WRT AbstractStateMachine, state handlers.
         while (!Application.QUEUE.isEmpty()) {
-            try {
-                SCXMLTestHelper.fireEvent(exec, Application.QUEUE.remove());
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            SCXMLTestHelper.fireEvent(exec, Application.QUEUE.remove());
         }
 
         Assertions.assertTrue(exec.getStatus().isFinal());

--- a/src/test/java/org/apache/commons/scxml2/issues/Issue112Test.java
+++ b/src/test/java/org/apache/commons/scxml2/issues/Issue112Test.java
@@ -94,7 +94,7 @@ public class Issue112Test {
         }
 
         @Override
-        public void execute(ActionExecutionContext exctx) throws ModelException, SCXMLExpressionException {
+        public void execute(ActionExecutionContext exctx) {
 
             Application.QUEUE.add(event);
 

--- a/src/test/java/org/apache/commons/scxml2/model/CustomActionTest.java
+++ b/src/test/java/org/apache/commons/scxml2/model/CustomActionTest.java
@@ -36,7 +36,7 @@ public class CustomActionTest {
     }
 
     @Test
-    public void testAddGoodCustomAction01() throws Exception {
+    public void testAddGoodCustomAction01() {
         new CustomAction("http://my.actions.domain/CUSTOM", "hello",
             Hello.class);
     }

--- a/src/test/java/org/apache/commons/scxml2/model/CustomActionTest.java
+++ b/src/test/java/org/apache/commons/scxml2/model/CustomActionTest.java
@@ -43,55 +43,42 @@ public class CustomActionTest {
 
     @Test
     public void testAddBadCustomAction01() {
-        try {
-            new CustomAction(null, "hello", Hello.class);
-            Assertions.fail("Added custom action with illegal namespace");
-        } catch (IllegalArgumentException iae) {
-            // Expected
-        }
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new CustomAction(null, "hello", Hello.class),
+                "Added custom action with illegal namespace");
     }
 
     @Test
     public void testAddBadCustomAction02() {
-        try {
-            new CustomAction("  ", "hello", Hello.class);
-            Assertions.fail("Added custom action with illegal namespace");
-        } catch (IllegalArgumentException iae) {
-            // Expected
-        }
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new CustomAction("  ", "hello", Hello.class),
+                "Added custom action with illegal namespace");
     }
 
     @Test
     public void testAddBadCustomAction03() {
-        try {
-            new CustomAction("http://my.actions.domain/CUSTOM", "",
-                Hello.class);
-            Assertions.fail("Added custom action with illegal local name");
-        } catch (IllegalArgumentException iae) {
-            // Expected
-        }
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new CustomAction("http://my.actions.domain/CUSTOM", "", Hello.class),
+                "Added custom action with illegal local name");
     }
 
     @Test
     public void testAddBadCustomAction04() {
-        try {
-            new CustomAction("http://my.actions.domain/CUSTOM", "  ",
-                Hello.class);
-            Assertions.fail("Added custom action with illegal local name");
-        } catch (IllegalArgumentException iae) {
-            // Expected
-        }
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new CustomAction("http://my.actions.domain/CUSTOM", "  ", Hello.class),
+                "Added custom action with illegal local name");
     }
 
     @Test
     public void testAddBadCustomAction05() {
-        try {            
-            new CustomAction("http://www.w3.org/2005/07/scxml", "foo",
-                Hello.class);
-            Assertions.fail("Added custom action in the SCXML namespace");
-        } catch (IllegalArgumentException iae) {
-            // Expected
-        }
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new CustomAction("http://www.w3.org/2005/07/scxml", "foo", Hello.class),
+                "Added custom action in the SCXML namespace");
     }
 
     // Hello World example using the SCXML <log> action

--- a/src/test/java/org/apache/commons/scxml2/model/Hello.java
+++ b/src/test/java/org/apache/commons/scxml2/model/Hello.java
@@ -55,7 +55,7 @@ public class Hello extends Action {
     }
 
     @Override
-    public void execute(ActionExecutionContext exctx) throws ModelException, SCXMLExpressionException {
+    public void execute(ActionExecutionContext exctx) {
         if (exctx.getAppLog().isInfoEnabled()) {
             exctx.getAppLog().info("Hello " + name);
         }

--- a/src/test/java/org/apache/commons/scxml2/model/ScxmlInitialAttributeTest.java
+++ b/src/test/java/org/apache/commons/scxml2/model/ScxmlInitialAttributeTest.java
@@ -18,7 +18,7 @@ package org.apache.commons.scxml2.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.StringReader;
 
@@ -75,12 +75,11 @@ public class ScxmlInitialAttributeTest {
     }
 
     @Test
-    public void testIllegalInitial() throws Exception {
-        try {
-            SCXMLTestHelper.parse(new StringReader(SCXML_WITH_ILLEGAL_INITIAL), null);
-            fail("SCXML reading should have failed due to the illegal state ID in SCXML.");
-        } catch (ModelException e) {
-            // expected because of the non-existing initial state id
-        }
+    public void testIllegalInitial() {
+        // expected because of the non-existing initial state id
+        assertThrows(
+                ModelException.class,
+                () -> SCXMLTestHelper.parse(new StringReader(SCXML_WITH_ILLEGAL_INITIAL), null),
+                "SCXML reading should have failed due to the illegal state ID in SCXML.");
     }
 }

--- a/src/test/java/org/apache/commons/scxml2/w3c/W3CTests.java
+++ b/src/test/java/org/apache/commons/scxml2/w3c/W3CTests.java
@@ -611,7 +611,7 @@ public class W3CTests {
      * @throws Exception
      */
     protected void runAssert(final Assertions.Assertion assertion, final Tests tests, final Datamodel datamodel,
-                             final boolean status, final boolean singleTest, TestResults results) throws Exception {
+                             final boolean status, final boolean singleTest, TestResults results) {
         final Tests.Test test = tests.getTests().get(assertion.getId());
         if (test == null) {
             throw new IllegalStateException("No test configuration found for W3C IRP test with id: "+assertion.getId());


### PR DESCRIPTION
This PR cleans up the handling of exceptions in the test code:

1. The cumbersome idiom of `try`-`catch` with a `fail` call in the `try` block and additional assertions in the `catch` block were replaced with Jupiter's elegant `Assertions#assertThrows` call.
2. Redudant `throws` clauses were removed
3. `Issue112Test#test01issue112`'s code was cleaned up so it actually fails if an exception is thrown instead of catching it and printing it to `System.err`.