### PR TITLE
Update to JEXL 3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-jexl3</artifactId>
-      <version>3.2.1</version>
+      <version>3.3</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -377,7 +377,7 @@
           <artifactId>js</artifactId>
           <version>22.0.0</version>
           <scope>test</scope>
-        </dependency>  
+        </dependency>
         <dependency>
           <groupId>org.graalvm.js</groupId>
           <artifactId>js-scriptengine</artifactId>
@@ -401,9 +401,9 @@
               </additionalJOptions>
             </configuration>
           </plugin>
-        </plugins>      
+        </plugins>
       </build>
-    </profile>  
+    </profile>
     <profile>
       <id>rc</id>
       <distributionManagement>

--- a/src/main/java/org/apache/commons/scxml2/env/jexl/JexlEvaluator.java
+++ b/src/main/java/org/apache/commons/scxml2/env/jexl/JexlEvaluator.java
@@ -23,6 +23,7 @@ import org.apache.commons.jexl3.JexlBuilder;
 import org.apache.commons.jexl3.JexlExpression;
 import org.apache.commons.jexl3.JexlEngine;
 import org.apache.commons.jexl3.JexlScript;
+import org.apache.commons.jexl3.introspection.JexlPermissions;
 import org.apache.commons.scxml2.Context;
 import org.apache.commons.scxml2.Evaluator;
 import org.apache.commons.scxml2.EvaluatorProvider;
@@ -180,7 +181,8 @@ public class JexlEvaluator extends AbstractBaseEvaluator {
         // See javadoc of org.apache.commons.jexl2.JexlEngine#setFunctions(Map<String,Object> funcs) for detail.
         final Map<String, Object> funcs = new HashMap<>();
         funcs.put(null, JexlBuiltin.class);
-        return new JexlBuilder().namespaces(funcs).cache(256).create();
+        JexlPermissions permissions = JexlPermissions.RESTRICTED.compose("org.apache.commons.scxml2.*");
+        return new JexlBuilder().permissions(permissions).namespaces(funcs).cache(256).create();
     }
 
     /**


### PR DESCRIPTION
Default permissions have changed with JEXL 3.3; this PR allows the tests to run but still keeps allowed classes to a restricted set.