### PR TITLE
[feature] set up allowed class-permissions to JEXL constructor

### DIFF
--- a/src/main/java/org/apache/commons/scxml2/env/jexl/JexlEvaluator.java
+++ b/src/main/java/org/apache/commons/scxml2/env/jexl/JexlEvaluator.java
@@ -74,10 +74,20 @@ public class JexlEvaluator extends AbstractBaseEvaluator {
     /** The internal JexlEngine instance to use. */
     private transient volatile JexlEngine jexlEngine;
 
+    /** Optional: saves user defined packages, which JEXL should allow for evaluation */
+    private String[] customAllowedClasses;
+
     /** Constructor. */
     public JexlEvaluator() {
         jexlEngine = getJexlEngine();
     }
+
+    /** Constructor with further allowed classes or packages. Use an asterix for all classes in a package */
+    public JexlEvaluator(String... customAllowedClasses) {
+        this.customAllowedClasses = customAllowedClasses;
+        jexlEngine = getJexlEngine();
+    }
+
 
     @Override
     public String getSupportedDatamodel() {
@@ -176,7 +186,7 @@ public class JexlEvaluator extends AbstractBaseEvaluator {
 
     /**
      * Create the internal JexlEngine member during the initialization.
-     * This method can be overriden to specify more detailed options
+     * This method can be overridden to specify more detailed options
      * into the JexlEngine.
      * @return new JexlEngine instance
      */
@@ -185,7 +195,13 @@ public class JexlEvaluator extends AbstractBaseEvaluator {
         // See javadoc of org.apache.commons.jexl2.JexlEngine#setFunctions(Map<String,Object> funcs) for detail.
         final Map<String, Object> funcs = new HashMap<>();
         funcs.put(null, JexlBuiltin.class);
+
         JexlPermissions permissions = JexlPermissions.RESTRICTED.compose("org.apache.commons.scxml2.*");
+
+        if(customAllowedClasses != null && customAllowedClasses.length > 0) {
+            permissions = permissions.compose(customAllowedClasses);
+        }
+
         return new JexlBuilder().permissions(permissions).namespaces(funcs).cache(256).create();
     }
 

--- a/src/test/java/com/custom/Payload.java
+++ b/src/test/java/com/custom/Payload.java
@@ -1,0 +1,20 @@
+package com.custom;
+
+public class Payload {
+
+    private final int id;
+    private final String someString;
+
+    public Payload(int id, String someString) {
+        this.id = id;
+        this.someString = someString;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getSomeString() {
+        return someString;
+    }
+}

--- a/src/test/java/org/apache/commons/scxml2/env/jexl/JexlEvaluatorTest.java
+++ b/src/test/java/org/apache/commons/scxml2/env/jexl/JexlEvaluatorTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.scxml2.env.jexl;
 
+import com.custom.Payload;
 import org.apache.commons.scxml2.Context;
 import org.apache.commons.scxml2.Evaluator;
 import org.apache.commons.scxml2.SCXMLExpressionException;
@@ -60,4 +61,17 @@ public class JexlEvaluatorTest {
                 "JexlEvaluator: Incorrect error message");
     }
 
+    @Test
+    void testEvalInCustomClass() throws SCXMLExpressionException {
+
+        // Arrange
+        final Evaluator eval = new JexlEvaluator("com.custom.*");
+        ctx.set("payload", new Payload(1, "hello"));
+
+        // Act
+        final Object result = eval.evalScript(ctx, "payload.getId()");
+
+        // Assert
+        Assertions.assertEquals(1, result);
+    }
 }


### PR DESCRIPTION
hi,

I had some trouble by using commons-scxml, because JEXL doesn't know my objects. Unfortunately JEXL is not very verbose and I took some time to understand that there are permissions. `commons-scxml` has no "easy" way to add some custom permissions and it needs a deeper understanding to see that the JexlEvaluator has to derive with an overridden `createJexlEngine`-method.

This PR contains a new constructor for JexlEvaluator which allows a custom set of classes which is used in `createJexlEngine()`. Moreover there is a test now, which supportes the usage of classes outside the allowed java- and sxcml2-packages.

I hope it finds a way into this great library 😊